### PR TITLE
feat: add scan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,22 @@ xs-dev include
 
 Updates the `manifest.json` with the path to the dependency.
 
+### Scan for available devices
+
+If the default device discovery is having trouble finding the correct port when running a project, use this command to find available ports to pass through the `--port` flag:
+
+```
+$ xs-dev scan
+
+✔ Found the following available devices!
+  Port                         Device                      Features
+  /dev/cu.usbserial-0001       ESP8266EX                   WiFi
+  /dev/cu.usbserial-DN02N5XK   ESP32-D0WDQ6 (revision 0)   WiFi, BT, Dual Core, Coding Scheme None
+
+$ xs-dev run --port /dev/cu.usbserial-0001 --device esp8266
+```
+
+
 ### Add a remote dependency (Coming soon)
 
 ```

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "axios": "^0.24.0",
     "gluegun": "^5.0.0",
+    "serialport": "^10.3.0",
     "serve-handler": "^6.1.3",
     "tar-fs": "^2.1.1",
     "unzip-stream": "^0.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ specifiers:
   gluegun: ^5.0.0
   jest: ^27.4.0
   prettier: ^2.5.1
+  serialport: ^10.3.0
   serve-handler: ^6.1.3
   tar-fs: ^2.1.1
   ts-jest: ^27.1.0
@@ -29,6 +30,7 @@ specifiers:
 dependencies:
   axios: 0.24.0
   gluegun: 5.0.0
+  serialport: 10.3.0
   serve-handler: 6.1.3
   tar-fs: 2.1.1
   unzip-stream: 0.3.1
@@ -851,6 +853,97 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
     dev: true
+
+  /@serialport/binding-mock/10.2.2:
+    resolution: {integrity: sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@serialport/bindings-interface': 1.2.1
+      debug: 4.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@serialport/bindings-cpp/10.6.3:
+    resolution: {integrity: sha512-jmALQ62JvIlCIx8osWifVXX1GoftlTPiX/HuEYeCYlRmtwXrbBzoD8dXu48YfGoZ/dwaYYKTsJarHqFoPq809Q==}
+    engines: {node: '>=12.17.0 <13.0 || >=14.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@serialport/bindings-interface': 1.2.1
+      '@serialport/parser-readline': 10.3.0
+      debug: 4.3.3
+      node-addon-api: 4.3.0
+      node-gyp-build: 4.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@serialport/bindings-interface/1.2.1:
+    resolution: {integrity: sha512-63Dyqz2gtryRDDckFusOYqLYhR3Hq/M4sEdbF9i/VsvDb6T+tNVgoAKUZ+FMrXXKnCSu+hYbk+MTc0XQANszxw==}
+    engines: {node: ^12.22 || ^14.13 || >=16}
+    dev: false
+
+  /@serialport/parser-byte-length/10.3.0:
+    resolution: {integrity: sha512-pJ/VoFemzKRRNDHLhFfPThwP40QrGaEnm9TtwL7o2GihEPwzBg3T0bN13ew5TpbbUYZdMpUtpm3CGfl6av9rUQ==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@serialport/parser-cctalk/10.3.0:
+    resolution: {integrity: sha512-8ujmk8EvVbDPrNF4mM33bWvUYJOZ0wXbY3WCRazHRWvyCdL0VO0DQvW81ZqgoTpiDQZm5r8wQu9rmuemahF6vQ==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@serialport/parser-delimiter/10.3.0:
+    resolution: {integrity: sha512-9E4Vj6s0UbbcCCTclwegHGPYjJhdm9qLCS0lowXQDEQC5naZnbsELemMHs93nD9jHPcyx1B4oXkMnVZLxX5TYw==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@serialport/parser-inter-byte-timeout/10.3.0:
+    resolution: {integrity: sha512-wKP0QK85NHgvT6BBB1qBfKBBU4pf8kespNXAZBUYmFT+P4n8r8IZE2mqigCD+AiZcfWNQoAizwOsT/Jx/qeVig==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@serialport/parser-packet-length/10.3.0:
+    resolution: {integrity: sha512-bj0cWzt8YSQj/E5fRQVYdi4TsfTlZQrXlXrUwjyTsCONv8IPOHzsz+yY0fw5SEMiJtaLyqvPkCHLsttOd/zFsg==}
+    engines: {node: '>=8.6.0'}
+    dev: false
+
+  /@serialport/parser-readline/10.3.0:
+    resolution: {integrity: sha512-ki3ATZ3/RAqnqGROBKE7k+OeZ0DZXZ53GTca4q71OU5RazbbNhTOBQLKLXD3v9QZXCMJdg4hGW/2Y0DuMUqMQg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@serialport/parser-delimiter': 10.3.0
+    dev: false
+
+  /@serialport/parser-ready/10.3.0:
+    resolution: {integrity: sha512-1owywJ4p592dJyVrEJZPIh6pUZ3/y/LN6kGTDH2wxdewRUITo/sGvDy0er5i2+dJD3yuowiAz0dOHSdz8tevJA==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@serialport/parser-regex/10.3.0:
+    resolution: {integrity: sha512-tIogTs7CvTH+UUFnsvE7i33MSISyTPTGPWlglWYH2/5coipXY503jlaYS1YGe818wWNcSx6YAjMZRdhTWwM39w==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@serialport/parser-slip-encoder/10.3.0:
+    resolution: {integrity: sha512-JI0ILF5sylWn8f0MuMzHFBix/iMUTa79/Z95KaPZYnVaEdA7h7hh/o21Jmon/26P3RJwL1SNJCjZ81zfan+LtQ==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@serialport/parser-spacepacket/10.3.0:
+    resolution: {integrity: sha512-PDF73ClEPsClD1FEJZHNuBevDKsJCkqy/XD5+S5eA6+tY5D4HLrVgSWsg+3qqB6+dlpwf2CzHe+uO8D3teuKHA==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@serialport/stream/10.3.0:
+    resolution: {integrity: sha512-7sooi5fHogYNVEJwxVdg872xO6TuMgQd2E9iRmv+o8pk/1dbBnPkmH6Ka3st1mVE+0KnIJqVlgei+ncSsqXIGw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@serialport/bindings-interface': 1.2.1
+      debug: 4.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@sinonjs/commons/1.8.3:
     resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
@@ -1810,7 +1903,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /decamelize-keys/1.1.0:
     resolution: {integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=}
@@ -3823,11 +3915,19 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: true
+
+  /node-addon-api/4.3.0:
+    resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
+    dev: false
+
+  /node-gyp-build/4.3.0:
+    resolution: {integrity: sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==}
+    hasBin: true
+    dev: false
 
   /node-int64/0.4.0:
     resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}
@@ -4379,6 +4479,28 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+
+  /serialport/10.3.0:
+    resolution: {integrity: sha512-MZMRlQgWOG7boLkJwm200Z3W39GcFmGo3tWxQrvyrZpH7W1p3t16M1VBglVxR6wXRF8qm01VxXBA+rNV7fPMVA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@serialport/binding-mock': 10.2.2
+      '@serialport/bindings-cpp': 10.6.3
+      '@serialport/parser-byte-length': 10.3.0
+      '@serialport/parser-cctalk': 10.3.0
+      '@serialport/parser-delimiter': 10.3.0
+      '@serialport/parser-inter-byte-timeout': 10.3.0
+      '@serialport/parser-packet-length': 10.3.0
+      '@serialport/parser-readline': 10.3.0
+      '@serialport/parser-ready': 10.3.0
+      '@serialport/parser-regex': 10.3.0
+      '@serialport/parser-slip-encoder': 10.3.0
+      '@serialport/parser-spacepacket': 10.3.0
+      '@serialport/stream': 10.3.0
+      debug: 4.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /serve-handler/6.1.3:
     resolution: {integrity: sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==}

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -13,6 +13,12 @@ const command: GluegunCommand<XSDevToolbox> = {
       process.exit(0)
     }
 
+    if (system.which('esptool.py') === null) {
+      print.error(
+        'esptool.py required to scan for devices. Please setup environment for ESP8266 or ESP32 before continuing:\n xs-dev setup --device esp32\n xs-dev setup --device esp8266.'
+      )
+    }
+
     const spinner = print.spin()
 
     spinner.start('Scanning for devices...')

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,0 +1,27 @@
+import type { GluegunCommand } from 'gluegun'
+import type { XSDevToolbox } from '../types'
+
+const command: GluegunCommand<XSDevToolbox> = {
+  name: 'scan',
+  description: 'Look for available devices',
+  run: async (toolbox) => {
+    const { parameters, print, system } = toolbox
+    if (parameters.options.help !== undefined) {
+      print.printCommands(toolbox, ['scan'])
+      process.exit(0)
+    }
+
+    const spinner = print.spin()
+
+    spinner.start('Scanning for devices...')
+
+    const result = await system.exec(`esptool.py read_mac`)
+
+    print.debug(result.toString())
+
+    spinner.succeed('Found the following available devices!')
+    print.table([['Device', 'Port']])
+  },
+}
+
+export default command

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -27,7 +27,7 @@ const command: GluegunCommand<XSDevToolbox> = {
     const result = await Promise.all<Buffer[]>(
       ports
         .filter((port) => port.serialNumber !== undefined)
-        .map((port) => system.exec(`esptool.py --port ${port.path} read_mac`))
+        .map((port) => system.exec(`esptool.py --port ${port.path} read_mac`)) // eslint-disable-line @typescript-eslint/promise-function-async
     )
 
     const record = parseScanResult(result.map(String).join('\n'))

--- a/src/toolbox/scan/parse.ts
+++ b/src/toolbox/scan/parse.ts
@@ -22,6 +22,7 @@ export function parseScanResult(output: string): ScanResult {
         state = 'deviceFound'
       }
       if (line.includes('failed to connect') && currentPort !== null) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete result[currentPort]
         currentPort = null
         state = 'searching'

--- a/src/toolbox/scan/parse.ts
+++ b/src/toolbox/scan/parse.ts
@@ -1,0 +1,48 @@
+type ScanResult = Record<string, { device: string; features: string }>
+type ParseState = 'searching' | 'portFound' | 'deviceFound' | 'featuresFound'
+
+export function parseScanResult(output: string): ScanResult {
+  const lines = output.split('\n')
+  let state: ParseState = 'searching'
+  let currentPort: string | null = null
+
+  return lines.reduce<ScanResult>((result, line) => {
+    if (state === 'searching') {
+      if (line.startsWith('Serial port')) {
+        currentPort = line.replace('Serial port ', '').replace('tty', 'cu')
+        result[currentPort] = { device: '', features: '' }
+        state = 'portFound'
+      }
+    }
+
+    if (state === 'portFound') {
+      if (line.startsWith('Chip is ') && currentPort !== null) {
+        const device = line.replace('Chip is ', '')
+        result[currentPort].device = device
+        state = 'deviceFound'
+      }
+      if (line.includes('failed to connect') && currentPort !== null) {
+        delete result[currentPort]
+        currentPort = null
+        state = 'searching'
+      }
+    }
+
+    if (state === 'deviceFound') {
+      if (line.startsWith('Features: ') && currentPort !== null) {
+        const features = line.replace('Features: ', '')
+        result[currentPort].features = features
+        state = 'featuresFound'
+      }
+    }
+
+    if (state === 'featuresFound') {
+      if (line.startsWith('Hard resetting')) {
+        currentPort = null
+        state = 'searching'
+      }
+    }
+
+    return result
+  }, {})
+}


### PR DESCRIPTION
Fixes #12 

- [X] Includes documentation for this new feature
- [X] Tested locally

This feature uses [SerialPort](https://serialport.io/) to list all ports and call `esptool.py` for each relevant port since `esptool.py` stops at the first available device, which is an issue if you have multiple devices connected for testing. 