### PR TITLE
feat: include pico in run and setup device list, add simulators list

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -65,6 +65,18 @@ const command: GluegunCommand<XSDevToolbox> = {
         'esp32/saola_wroom',
         'esp32/saola_wrover',
         'wasm',
+        'pico',
+        'pico/ili9341',
+        'pico/pico_display',
+        'pico/pico_display_2',
+        'simulator/moddable_one',
+        'simulator/moddable_two',
+        'simulator/moddable_three',
+        'simulator/m5stickc',
+        'simulator/m5paper',
+        'simulator/nodemcu',
+        'simulator/pico_display',
+        'simulator/pico_display_2',
       ]
       const { device: selectedDevice } = await prompt.ask([
         {
@@ -148,7 +160,7 @@ const command: GluegunCommand<XSDevToolbox> = {
 
     await system.exec(`mcconfig -d -m -p ${targetPlatform}`, {
       cwd: projectPath,
-      stdout: process.stdout,
+      process,
     })
 
     spinner.stop()
@@ -170,6 +182,8 @@ const command: GluegunCommand<XSDevToolbox> = {
           'Started server on port 8080, go to http://localhost:8080 in your browser to view the simulator'
         )
       })
+    } else {
+      process.exit(0)
     }
   },
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,6 +4,7 @@ import handler from 'serve-handler'
 import { createServer } from 'http'
 import type { Device, XSDevToolbox } from '../types'
 import { collectChoicesFromTree } from '../toolbox/prompt/choices'
+import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 
 interface RunOptions {
   device?: Device
@@ -12,17 +13,6 @@ interface RunOptions {
   listExamples?: boolean
   listDevices?: boolean
 }
-
-const DEVICE_ALIAS: Record<Device | 'esp8266', string> = Object.freeze({
-  esp8266: 'esp',
-  darwin: 'mac',
-  windows_nt: 'win',
-  linux: 'lin',
-  esp: 'esp',
-  esp32: 'esp32',
-  wasm: 'wasm',
-  pico: 'pico',
-})
 
 const command: GluegunCommand<XSDevToolbox> = {
   name: 'run',

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,6 +2,7 @@ import type { GluegunCommand } from 'gluegun'
 import { type as platformType } from 'os'
 import type { Device, XSDevToolbox } from '../types'
 import setupFontbm from '../toolbox/setup/fontbm'
+import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 
 interface SetupOptions {
   device?: Device
@@ -23,7 +24,13 @@ const command: GluegunCommand<XSDevToolbox> = {
     let target: Device = device ?? currentPlatform
 
     if (device === undefined && listDevices) {
-      const choices = ['esp8266', 'esp32', 'wasm', currentPlatform]
+      const choices = [
+        'esp8266',
+        'esp32',
+        'pico',
+        'wasm',
+        DEVICE_ALIAS[currentPlatform],
+      ]
       const { device: selectedDevice } = await prompt.ask([
         {
           type: 'autocomplete',

--- a/src/toolbox/prompt/devices.ts
+++ b/src/toolbox/prompt/devices.ts
@@ -1,0 +1,12 @@
+import { Device } from '../../types'
+
+export const DEVICE_ALIAS: Record<Device | 'esp8266', string> = Object.freeze({
+  esp8266: 'esp',
+  darwin: 'mac',
+  windows_nt: 'win',
+  linux: 'lin',
+  esp: 'esp',
+  esp32: 'esp32',
+  wasm: 'wasm',
+  pico: 'pico',
+})


### PR DESCRIPTION
Fixes #29 

Also resolves displaying the correct device alias for the current OS platform in the `setup` command's list of devices. 