### PR TITLE
scan continues on failure #27

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -27,7 +27,13 @@ const command: GluegunCommand<XSDevToolbox> = {
     const result = await Promise.all<Buffer[]>(
       ports
         .filter((port) => port.serialNumber !== undefined)
-        .map((port) => system.exec(`esptool.py --port ${port.path} read_mac`)) // eslint-disable-line @typescript-eslint/promise-function-async
+        .map(async (port) => {
+          try {
+            return await system.exec(`esptool.py --port ${port.path} read_mac`) // eslint-disable-line @typescript-eslint/promise-function-async
+          }
+          catch {
+          }
+        })
     )
 
     const record = parseScanResult(result.map(String).join('\n'))


### PR DESCRIPTION
This fixes the problem of `esptool.py`failing on one device getting in the way of scanning other devices. It doesn't try to add support for scanning Pico.