### PR TITLE
fix(pico): set PICO_GCC_ROOT to brew prefix on mac

### DIFF
--- a/src/toolbox/setup/pico.ts
+++ b/src/toolbox/setup/pico.ts
@@ -40,6 +40,10 @@ export default async function (): Promise<void> {
 
     spinner.start('Tapping ArmMbed formulae and installing arm-embed-gcc')
     await installMacDeps(spinner)
+
+    const brewPrefix = await system.run('brew --prefix')
+    process.env.PICO_GCC_ROOT = brewPrefix
+    await upsert(EXPORTS_FILE_PATH, `export PICO_GCC_ROOT=${brewPrefix}`)
   }
 
   if (OS === 'linux') {


### PR DESCRIPTION
When attempting to run the hello world example for the pico on my M1 Mac, I ran into an error related to the directory for `arm-none-eabi-gcc`. The default directory within the [Moddable make file](https://github.com/Moddable-OpenSource/moddable/blob/public/tools/mcconfig/make.pico.mk#L26) is `/usr/local`, which is the default for Homebrew on Mac machines running on Intel chips. 

This PR fixes the error by setting the `PICO_GCC_ROOT` environment variable to the `brew --prefix` result on MacOS. Instead of doing it conditional to the architecture of the machine, `PICO_GCC_ROOT` will always be set for safety. 