### PR TITLE
feat(pico): include picotool CLI in setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ xs-dev run --example helloworld --device=wasm
 
 ### Raspberry Pi Pico SDK install / setup
 
-This process automates the instructions for downloading all the dependencies for the Pico SDK. These dependencies will be placed in the `~/.local/share/pico` directory, which will be created if it doesn't exist.
+This process automates the instructions for downloading all the dependencies for the Pico SDK. These dependencies will be placed in the `~/.local/share/pico` directory, which will be created if it doesn't exist. It will also include the [`picotool` CLI](https://github.com/raspberrypi/picotool) to help with scanning for connected devices.
 
 Run script for platform setup:
 

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -14,7 +14,7 @@ const command: GluegunCommand<XSDevToolbox> = {
     }
 
     if (system.which('esptool.py') === null) {
-      print.error(
+      print.warning(
         'esptool.py required to scan for devices. Please setup environment for ESP8266 or ESP32 before continuing:\n xs-dev setup --device esp32\n xs-dev setup --device esp8266.'
       )
     }
@@ -30,9 +30,7 @@ const command: GluegunCommand<XSDevToolbox> = {
         .map(async (port) => {
           try {
             return await system.exec(`esptool.py --port ${port.path} read_mac`) // eslint-disable-line @typescript-eslint/promise-function-async
-          }
-          catch {
-          }
+          } catch {}
         })
     )
 

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -29,6 +29,12 @@ const command: GluegunCommand<XSDevToolbox> = {
         .filter((port) => port.serialNumber !== undefined)
         .map(async (port) => {
           try {
+            if (
+              port.manufacturer?.includes('Raspberry Pi') === true &&
+              system.which('picotool') !== null
+            ) {
+              return await system.exec(`picotool info -fa`)
+            }
             return await system.exec(`esptool.py --port ${port.path} read_mac`) // eslint-disable-line @typescript-eslint/promise-function-async
           } catch {}
         })

--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -66,7 +66,7 @@ export default async function (): Promise<void> {
 
   // 6. append 'source $IDF_PATH/export.sh' to shell profile
   spinner.info('Sourcing esp-idf environment')
-  await upsert(EXPORTS_FILE_PATH, `source $IDF_PATH/export.sh`)
+  await upsert(EXPORTS_FILE_PATH, `source $IDF_PATH/export.sh 1> /dev/null`)
   await system.exec('source $IDF_PATH/export.sh', {
     shell: process.env.SHELL,
   })

--- a/src/toolbox/setup/pico/linux.ts
+++ b/src/toolbox/setup/pico/linux.ts
@@ -5,7 +5,7 @@ export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
   await execWithSudo(
-    'apt-get install --yes cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential',
+    'apt-get install --yes cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libusb-1.0.0-dev pkg-config',
     { stdout: process.stdout }
   )
   spinner.succeed()

--- a/src/toolbox/setup/pico/mac.ts
+++ b/src/toolbox/setup/pico/mac.ts
@@ -5,6 +5,6 @@ export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
   await system.exec('brew tap ArmMbed/homebrew-formulae')
-  await system.exec(`brew install arm-none-eabi-gcc`)
+  await system.exec(`brew install arm-none-eabi-gcc libusb pkg-config`)
   spinner.succeed()
 }


### PR DESCRIPTION
The [picotool CLI](https://github.com/raspberrypi/picotool) is a handy utility for inspecting and interacting with devices using the pico chipset (RP2040). This is potentially useful for xs-dev users as a means of including pico info in the `scan` command output. The `picotool` CLI itself doesn't not include a `list` feature but the `info` command may provide a similar output. 

Sample output:
```text
❯ picotool info -fa
The device was asked to reboot into BOOTSEL mode so the command can be executed.

Program Information
 name:          helloworld
 web site:      https://github.com/Moddable-OpenSource
 features:      USB stdin / stdout
 binary start:  0x10000000
 binary end:    0x1003a120

Fixed Pin Information
 none

Build Information
 sdk version:       1.1.0
 pico_board:        pico
 boot2_name:        boot2_w25q080
 build date:        Apr  1 2022
 build attributes:  Debug

Device Information
 flash size:   2048K
 ROM version:  1

               The device was asked to reboot back into application mode.
```

Results in:

```text
✔ Found the following available devices!
  Port                       Device   Features
  /dev/cu.usbmodem11444401   pico     USB stdin / stdout
```