### PR TITLE
fix(scan): reboot pico boards in BOOTSEL before scan

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -3,6 +3,13 @@ import type { GluegunCommand } from 'gluegun'
 import type { XSDevToolbox } from '../types'
 import { parseScanResult } from '../toolbox/scan/parse'
 
+// eslint-disable-next-line
+function sleep(timeout: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout)
+  })
+}
+
 const command: GluegunCommand<XSDevToolbox> = {
   name: 'scan',
   description: 'Look for available devices',
@@ -23,6 +30,13 @@ const command: GluegunCommand<XSDevToolbox> = {
 
     spinner.start('Scanning for devices...')
 
+    const hasPicotool = system.which('picotool') !== null
+
+    if (hasPicotool) {
+      await system.exec('picotool reboot -fa')
+      await sleep(1000)
+    }
+
     const ports = await SerialPort.list()
     const result: Array<
       [output: Buffer, port: string] | [output: undefined, port: string]
@@ -33,7 +47,7 @@ const command: GluegunCommand<XSDevToolbox> = {
           try {
             if (
               port.manufacturer?.includes('Raspberry Pi') === true &&
-              system.which('picotool') !== null
+              hasPicotool
             ) {
               return await system
                 .exec(`picotool info -fa`)


### PR DESCRIPTION
Fixes #45 

Uses the suggested command `picotool reboot -fa` to set any connected pico board in boot select into application mode for serial discovery, and it does require a second to reboot before appearing as an available device. 

The data returned by `Serialport.list` does not include USB bus information, so running `picotool` against a particular USB address is not possible unless I am able to refactor to use [node-usb](https://node-usb.github.io/node-usb/) instead. Node-usb might actually be the more appropriate library for the use case of `xs-dev`, so it is worth attempting the refactor in a separate branch. 