### PR TITLE
fix(scan): filter picotool info by bus + address

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "serialport": "^10.3.0",
     "serve-handler": "^6.1.3",
     "tar-fs": "^2.1.1",
-    "unzip-stream": "^0.3.1"
+    "unzip-stream": "^0.3.1",
+    "usb": "^2.2.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ specifiers:
   ts-node: ^10.4.0
   typescript: ^4.5.x
   unzip-stream: ^0.3.1
+  usb: ^2.2.0
 
 dependencies:
   axios: 0.24.0
@@ -34,6 +35,7 @@ dependencies:
   serve-handler: 6.1.3
   tar-fs: 2.1.1
   unzip-stream: 0.3.1
+  usb: 2.2.0
 
 devDependencies:
   '@changesets/cli': 2.19.0
@@ -1106,6 +1108,10 @@ packages:
     dependencies:
       '@types/node': 16.11.19
     dev: true
+
+  /@types/w3c-web-usb/1.0.6:
+    resolution: {integrity: sha512-cSjhgrr8g4KbPnnijAr/KJDNKa/bBa+ixYkywFRvrhvi9n1WEl7yYbtRyzE6jqNQiSxxJxoAW3STaOQwJHndaw==}
+    dev: false
 
   /@types/yargs-parser/20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==}
@@ -5080,6 +5086,16 @@ packages:
     dependencies:
       punycode: 2.1.1
     dev: true
+
+  /usb/2.2.0:
+    resolution: {integrity: sha512-t5ael9c4BaZfP1LsBx8XPz4xDGGXvEVmCUyzmeXPwyUyPZrETwOWyPykJUXJpGXga46fI+kBcZZ9AYYdqhpcHA==}
+    engines: {node: '>=10.16.0'}
+    requiresBuild: true
+    dependencies:
+      '@types/w3c-web-usb': 1.0.6
+      node-addon-api: 4.3.0
+      node-gyp-build: 4.3.0
+    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,4 +1,5 @@
 import { SerialPort } from 'serialport'
+import { findBySerialNumber } from 'usb'
 import type { GluegunCommand } from 'gluegun'
 import type { XSDevToolbox } from '../types'
 import { parseScanResult } from '../toolbox/scan/parse'
@@ -51,8 +52,11 @@ const command: GluegunCommand<XSDevToolbox> = {
               port.manufacturer?.includes('Raspberry Pi') === true &&
               hasPicotool
             ) {
+              const device = await findBySerialNumber(port.serialNumber ?? '')
+              const bus = String(device?.busNumber)
+              const address = String(device?.deviceAddress)
               return await system
-                .exec(`picotool info -fa`)
+                .exec(`picotool info --bus ${bus} --address ${address} -fa`)
                 .then((buffer) => [buffer, port.path])
             }
             return await system


### PR DESCRIPTION
Follow up from #46 to spike on using [node-usb](https://node-usb.github.io/node-usb/) to get the USB bus number and address to pass to the `picotool info` command. 