### PR TITLE
docs: add Search component w/ fuse.js

### DIFF
--- a/docs/src/components/Header/Header.astro
+++ b/docs/src/components/Header/Header.astro
@@ -4,6 +4,7 @@ import * as CONFIG from '../../config.ts';
 import SkipToContent from './SkipToContent.astro';
 import SidebarToggle from './SidebarToggle.tsx';
 import LanguageSelect from './LanguageSelect.tsx';
+import Search from './Search.tsx';
 
 const { currentPage } = Astro.props;
 const lang = currentPage && getLanguageFromURL(currentPage);
@@ -23,6 +24,7 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 		<div style="flex-grow: 1;"></div>
 		{KNOWN_LANGUAGE_CODES.length > 1 && <LanguageSelect lang={lang} client:idle />}
 	</nav>
+  <Search client:idle />
 </header>
 
 <style>
@@ -34,7 +36,6 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		overflow: hidden;
 		position: sticky;
 		top: 0;
 	}

--- a/docs/src/components/Header/Search.css
+++ b/docs/src/components/Header/Search.css
@@ -1,0 +1,39 @@
+.flex-column {
+  flex-direction: column;
+}
+
+input {
+  border: 1px solid #333333;
+  padding: 0.5rem 1rem;
+}
+
+button {
+  border-radius: 0px;
+  padding: 0.5rem;
+}
+
+#search-container ul {
+  background: white;
+  top: 2.6rem;
+  display: flex;
+  flex-direction: column;
+  left: 0;
+  position: absolute;
+  width: 100%;
+}
+
+#search-container ul.has-results {
+  border: 1px solid #333333;
+}
+
+#search-container ul li {
+  padding: 0.5rem 1rem;
+}
+
+ul a {
+  color: blue;
+}
+
+#search-container {
+  position: relative;
+}

--- a/docs/src/components/Header/Search.tsx
+++ b/docs/src/components/Header/Search.tsx
@@ -1,0 +1,58 @@
+import type { FunctionalComponent } from 'preact'
+import { h, Fragment } from 'preact'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import Fuse from 'fuse.js'
+import './Search.css'
+
+const SearchForm: FunctionalComponent = () => {
+  const fuse = useRef(null)
+  const [results, setResults] = useState([])
+
+  const searchContent = (event: SubmitEvent) => {
+    event.preventDefault()
+    const data = Object.fromEntries(
+      new FormData(event.currentTarget as HTMLFormElement)
+    )
+    const result = fuse.current.search(data.search)
+    setResults(result.map(({ item }) => item))
+  }
+
+  useEffect(() => {
+    fetch('/xs-dev/search-index.json')
+      .then((res) => res.json())
+      .then((content) => {
+        const options = { keys: ['title', 'description', 'content'] }
+        fuse.current = new Fuse(content, options)
+      })
+  }, [])
+
+  return (
+    <div class="flex flex-column" id="search-container">
+      <form method="GET" id="search-form" onSubmit={searchContent}>
+        <div role="search" class="flex flex-row">
+          <input
+            type="search"
+            id="search"
+            name="search"
+            aria-label="search documentation content"
+            placeholder="search documentation content"
+          />
+          <button type="submit">Search</button>
+        </div>
+      </form>
+      <ul
+        class={results.length > 0 ? 'has-results' : undefined}
+        aria-live="assertive"
+        aria-atomic="true"
+      >
+        {results.map((result) => (
+          <li>
+            <a href={result.url}>{result.title}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default SearchForm

--- a/docs/src/pages/search-index.json.ts
+++ b/docs/src/pages/search-index.json.ts
@@ -1,0 +1,18 @@
+export async function get() {
+  const pagesMeta = import.meta.glob('./en/**/*.md')
+  const pages = await Promise.all(
+    Object.values(pagesMeta).map(async (getInfo) => {
+      const { rawContent, url, frontmatter } = await getInfo()
+      return {
+        content: rawContent(),
+        url,
+        ...frontmatter,
+      }
+    })
+  )
+  const json = JSON.stringify(pages)
+
+  return {
+    body: json,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.0.0",
+    "fuse.js": "^6.6.2",
     "jest": "^27.4.0",
     "lit": "^2.1.3",
     "preact": "^10.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ specifiers:
   eslint-plugin-import: ^2.22.1
   eslint-plugin-node: ^11.1.0
   eslint-plugin-promise: ^5.0.0
+  fuse.js: ^6.6.2
   gluegun: ^5.0.0
   jest: ^27.4.0
   lit: ^2.1.3
@@ -69,6 +70,7 @@ devDependencies:
   eslint-plugin-import: 2.25.4_ffi3uiz42rv3jyhs6cr7p7qqry
   eslint-plugin-node: 11.1.0_eslint@7.32.0
   eslint-plugin-promise: 5.2.0_eslint@7.32.0
+  fuse.js: 6.6.2
   jest: 27.4.7_ts-node@10.4.0
   lit: 2.2.5
   preact: 10.7.3
@@ -3887,6 +3889,11 @@ packages:
 
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+    dev: true
+
+  /fuse.js/6.6.2:
+    resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
+    engines: {node: '>=10'}
     dev: true
 
   /gensync/1.0.0-beta.2:


### PR DESCRIPTION
To help with discovery of xs-dev information, this PR adds a Search component that uses [fuse.js](https://fusejs.io/) and a custom JSON endpoint to store the searchable content.

Preview:
![image](https://user-images.githubusercontent.com/3051193/176972431-e4098083-37e5-4c74-a1f1-0966b4b7a514.png)
