### PR TITLE
Windows support rework + Initial Windows Espressif support

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "serve-handler": "^6.1.3",
     "tar-fs": "^2.1.1",
     "unzip-stream": "^0.3.1",
-    "usb": "^2.2.0"
+    "usb": "^2.2.0",
+    "windows-shortcuts": "^0.1.6"
   },
   "devDependencies": {
     "@astrojs/lit": "^0.1.4",

--- a/src/toolbox/setup/constants.ts
+++ b/src/toolbox/setup/constants.ts
@@ -1,10 +1,17 @@
 import { filesystem } from 'gluegun'
+import { type as platformType } from 'os'
+import type { Device } from '../../types'
+
+const currentPlatform: Device = platformType().toLowerCase() as Device;
+const isWindows = currentPlatform === "windows_nt"
 
 export const HOME_DIR = filesystem.homedir()
-export const INSTALL_DIR = filesystem.resolve(HOME_DIR, '.local', 'share')
+export const INSTALL_DIR = isWindows ? filesystem.resolve(HOME_DIR, 'xs-dev') : filesystem.resolve(HOME_DIR, '.local', 'share')
 export const INSTALL_PATH =
   process.env.MODDABLE ?? filesystem.resolve(INSTALL_DIR, 'moddable')
-export const EXPORTS_FILE_PATH = filesystem.resolve(
+export const EXPORTS_FILE_PATH = isWindows ? 
+filesystem.resolve(INSTALL_DIR, "Moddable.bat") :
+filesystem.resolve(
   HOME_DIR,
   '.local',
   'share',

--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -5,9 +5,12 @@ import { moddableExists } from './moddable'
 import upsert from '../patching/upsert'
 import { installDeps as installMacDeps } from './esp32/mac'
 import { installDeps as installLinuxDeps } from './esp32/linux'
+import { installDeps as installWinDeps } from './esp32/windows'
+import { setEnv } from './windows'
 
 export default async function (): Promise<void> {
   const OS = platformType().toLowerCase()
+  const isWindows = OS === "windows_nt"
   const ESP_IDF_REPO = 'https://github.com/espressif/esp-idf.git'
   const ESP_BRANCH = 'v4.4'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
@@ -20,6 +23,13 @@ export default async function (): Promise<void> {
   if (!moddableExists()) {
     spinner.fail(
       'Moddable tooling required. Run `xs-dev setup` before trying again.'
+    )
+    process.exit(1)
+  }
+
+  if (isWindows && !(process.env.ISMODDABLECOMMANDPROMPT)) {
+    spinner.fail(
+      `Moddable tooling required. Run xs-dev commands from the Moddable Command Prompt.`
     )
     process.exit(1)
   }
@@ -48,32 +58,54 @@ export default async function (): Promise<void> {
     await installLinuxDeps(spinner)
   }
 
+  if (isWindows) {
+    await installWinDeps(spinner, ESP32_DIR, IDF_PATH)
+  }
+
   // 4. append IDF_PATH env export to shell profile
-  if (process.env.IDF_PATH === undefined) {
-    spinner.info('Configuring $IDF_PATH')
-    process.env.IDF_PATH = IDF_PATH
-    await upsert(EXPORTS_FILE_PATH, `export IDF_PATH=${IDF_PATH}`)
+  if (!isWindows) {
+    if (process.env.IDF_PATH === undefined) {
+      spinner.info('Configuring $IDF_PATH')
+      process.env.IDF_PATH = IDF_PATH
+      await upsert(EXPORTS_FILE_PATH, `export IDF_PATH=${IDF_PATH}`)
+    }
+  } else {
+    spinner.info('Configuring IDF_PATH environment variable')
+    await setEnv("IDF_PATH", IDF_PATH)
   }
 
   // 5. cd to IDF_PATH, run install.sh
-  spinner.start('Installing esp-idf tooling')
-  await system.exec('./install.sh', {
-    cwd: IDF_PATH,
-    shell: process.env.SHELL,
-    stdout: process.stdout,
-  })
-  spinner.succeed()
+  if (!isWindows) {
+    spinner.start('Installing esp-idf tooling')
+    await system.exec('./install.sh', {
+      cwd: IDF_PATH,
+      shell: process.env.SHELL,
+      stdout: process.stdout,
+    })
+    spinner.succeed()
+  } else {
+    spinner.start('Running ESP-IDF Tools install.bat')
+    await system.exec(`${IDF_PATH}\\install.bat`, {
+      cwd: IDF_PATH,
+      stdout: process.stdout,
+    })
+    spinner.succeed()
+  }
 
   // 6. append 'source $IDF_PATH/export.sh' to shell profile
-  spinner.info('Sourcing esp-idf environment')
-  await upsert(EXPORTS_FILE_PATH, `source $IDF_PATH/export.sh 1> /dev/null`)
-  await system.exec('source $IDF_PATH/export.sh', {
-    shell: process.env.SHELL,
-  })
+  if (!isWindows) {
+    spinner.info('Sourcing esp-idf environment')
+    await upsert(EXPORTS_FILE_PATH, `source $IDF_PATH/export.sh 1> /dev/null`)
+    await system.exec('source $IDF_PATH/export.sh', {
+      shell: process.env.SHELL,
+    })
+  } else {
+    await upsert(EXPORTS_FILE_PATH, `pushd %IDF_PATH% && call "%IDF_TOOLS_PATH%\\idf_cmd_init.bat" && popd`)
+  }
 
   spinner.succeed(`
   Successfully set up esp32 platform support for Moddable!
-  Test out the setup by starting a new terminal session, plugging in your device, and running: xs-dev run --example helloworld --device=esp32
-  If there is trouble finding the correct port, pass the "--port" flag to the above command with the path to the "/dev.cu.*" that matches your device.
+  Test out the setup by starting a new ${isWindows ? 'Moddable Command Prompt' : 'terminal session'}, plugging in your device, and running: xs-dev run --example helloworld --device=esp32
+  If there is trouble finding the correct port, pass the "--port" flag to the above command with the ${isWindows? "COM Port" :  "path to the /dev.cu.*"} that matches your device.
   `)
 }

--- a/src/toolbox/setup/esp32/windows.ts
+++ b/src/toolbox/setup/esp32/windows.ts
@@ -14,25 +14,26 @@ export async function installDeps(
     IDF_PATH: string
   ): Promise<void> {
     
-  
-    if (!esp32Exists()) {  
-      spinner.start('Downloading ESP-IDF Tools Installer')
-      const destination = filesystem.resolve(ESP32_DIR, 'esp-idf-tools-setup-online-2.15.exe')
-      const writer = filesystem.createWriteStream(destination)
-      const response = await axios.get(IDF_INSTALLER, {
-          responseType: 'stream',
-      })
-      response.data.pipe(writer)
-      await finishedPromise(writer)
-      spinner.succeed()
-
-      print.info(`When prompted, select "Use an Existing ESP-IDF Directory" and choose ${IDF_PATH}.`)
-      print.info('The "Full Installation" option is recommended.')
-      spinner.start('Running ESP-IDF Tools Installer')
-      await system.exec(`start /B ${destination}`)
-      spinner.succeed()
+    if (esp32Exists()) {
+      print.info(`ESP-IDF tooling exists at ${process.env.IDF_PATH}`)
+      return
     }
+  
+    spinner.start('Downloading ESP-IDF Tools Installer')
+    const destination = filesystem.resolve(ESP32_DIR, 'esp-idf-tools-setup-online-2.15.exe')
+    const writer = filesystem.createWriteStream(destination)
+    const response = await axios.get(IDF_INSTALLER, {
+        responseType: 'stream',
+    })
+    response.data.pipe(writer)
+    await finishedPromise(writer)
+    spinner.succeed()
 
+    print.info(`When prompted, select "Use an Existing ESP-IDF Directory" and choose ${IDF_PATH}.`)
+    print.info('The "Full Installation" option is recommended.')
+    spinner.start('Running ESP-IDF Tools Installer')
+    await system.exec(`start /B ${destination}`)
+    spinner.succeed()
   }
   
   export function esp32Exists(): boolean {

--- a/src/toolbox/setup/esp32/windows.ts
+++ b/src/toolbox/setup/esp32/windows.ts
@@ -1,0 +1,45 @@
+import { filesystem, print, system } from 'gluegun'
+import type { GluegunPrint } from 'gluegun'
+import axios from 'axios'
+import { promisify } from 'util'
+import { finished } from 'stream'
+
+const finishedPromise = promisify(finished)
+
+const IDF_INSTALLER = 'https://github.com/espressif/idf-installer/releases/download/online-2.15/esp-idf-tools-setup-online-2.15.exe'
+
+export async function installDeps(
+    spinner: ReturnType<GluegunPrint['spin']>,
+    ESP32_DIR: string,
+    IDF_PATH: string
+  ): Promise<void> {
+    
+  
+    if (!esp32Exists()) {  
+      spinner.start('Downloading ESP-IDF Tools Installer')
+      const destination = filesystem.resolve(ESP32_DIR, 'esp-idf-tools-setup-online-2.15.exe')
+      const writer = filesystem.createWriteStream(destination)
+      const response = await axios.get(IDF_INSTALLER, {
+          responseType: 'stream',
+      })
+      response.data.pipe(writer)
+      await finishedPromise(writer)
+      spinner.succeed()
+
+      print.info(`When prompted, select "Use an Existing ESP-IDF Directory" and choose ${IDF_PATH}.`)
+      print.info('The "Full Installation" option is recommended.')
+      spinner.start('Running ESP-IDF Tools Installer')
+      await system.exec(`start /B ${destination}`)
+      spinner.succeed()
+    }
+
+  }
+  
+  export function esp32Exists(): boolean {
+    return (
+      process.env.IDF_PATH !== undefined &&
+      process.env.IDF_TOOLS_PATH !== undefined &&
+      filesystem.exists(process.env.IDF_TOOLS_PATH) === 'dir' &&
+      filesystem.exists(process.env.IDF_PATH) === 'dir'
+    )
+  }

--- a/src/toolbox/setup/esp8266.ts
+++ b/src/toolbox/setup/esp8266.ts
@@ -11,12 +11,14 @@ import { moddableExists } from './moddable'
 import upsert from '../patching/upsert'
 import { installDeps as installMacDeps } from './esp8266/mac'
 import { installDeps as installLinuxDeps } from './esp8266/linux'
+import { installDeps as installWindowsDeps } from './esp8266/windows'
 
 const finishedPromise = promisify(finished)
 
 export default async function (): Promise<void> {
   const OS = platformType().toLowerCase()
-  const TOOLCHAIN = `https://www.moddable.com/private/esp8266.toolchain.${OS}.tgz`
+  const isWindows = OS === "windows_nt"
+  const TOOLCHAIN = isWindows ? 'https://www.moddable.com/private/esp8266.toolchain.win32.zip' : `https://www.moddable.com/private/esp8266.toolchain.${OS}.tgz`
   const ARDUINO_CORE =
     'https://github.com/esp8266/Arduino/releases/download/2.3.0/esp8266-2.3.0.zip'
   const ESP_RTOS_REPO = 'https://github.com/espressif/ESP8266_RTOS_SDK.git'
@@ -37,6 +39,13 @@ export default async function (): Promise<void> {
     process.exit(1)
   }
 
+  if (isWindows && !(process.env.ISMODDABLECOMMANDPROMPT)) {
+    spinner.fail(
+      `Moddable tooling required. Run xs-dev commands from the Moddable Command Prompt.`
+    )
+    process.exit(1)
+  }
+
   // 1. ensure ~/.local/share/esp directory
   spinner.info('Ensuring esp directory')
   filesystem.dir(ESP_DIR)
@@ -44,13 +53,23 @@ export default async function (): Promise<void> {
   // 2. download and untar xtensa toolchain
   if (filesystem.exists(TOOLCHAIN_PATH) === false) {
     spinner.start('Downloading xtensa toolchain')
-    const writer = extract(ESP_DIR, { readable: true })
-    const gunzip = createGunzip()
-    const response = await axios.get(TOOLCHAIN, {
-      responseType: 'stream',
-    })
-    response.data.pipe(gunzip).pipe(writer)
-    await finishedPromise(writer)
+    
+    if (!isWindows) {
+      const writer = extract(ESP_DIR, { readable: true })
+      const gunzip = createGunzip()
+      const response = await axios.get(TOOLCHAIN, {
+        responseType: 'stream',
+      })
+      response.data.pipe(gunzip).pipe(writer)
+      await finishedPromise(writer)
+    } else {
+      const writer = ZipExtract({path: ESP_DIR})
+      const response = await axios.get(TOOLCHAIN, {
+        responseType: 'stream'
+      })
+      response.data.pipe(writer)
+      await finishedPromise(writer)
+    }
     spinner.succeed()
   }
 
@@ -84,12 +103,23 @@ export default async function (): Promise<void> {
     await installLinuxDeps(spinner)
   }
 
-  // 7. create ESP_BARE env export in shell profile
-  if (process.env.ESP_BASE === undefined) {
-    spinner.info('Configuring $ESP_BASE')
-    process.env.ESP_BASE = ESP_DIR
-    await upsert(EXPORTS_FILE_PATH, `export ESP_BASE=${process.env.ESP_BASE}`)
+  if (isWindows) {
+    try {
+      await installWindowsDeps(spinner, ESP_DIR)
+    } catch (error) {
+      print.error(`Windows dependencies failed to install. Please review the information above.`)
+      process.exit(1)
+    }
   }
+
+  // 7. create ESP_BASE env export in shell profile
+  if (!isWindows) {
+    if (process.env.ESP_BASE === undefined) {
+      spinner.info('Configuring $ESP_BASE')
+      process.env.ESP_BASE = ESP_DIR
+      await upsert(EXPORTS_FILE_PATH, `export ESP_BASE=${process.env.ESP_BASE}`)
+    }
+  } // Windows case is handled in ./esp8266/windows.ts
 
   spinner.succeed(`
   Successfully set up esp8266 platform support for moddable!

--- a/src/toolbox/setup/esp8266/windows.ts
+++ b/src/toolbox/setup/esp8266/windows.ts
@@ -1,0 +1,92 @@
+import { system, filesystem, print } from 'gluegun'
+import { finished } from 'stream'
+import axios from 'axios'
+import type { GluegunPrint } from 'gluegun'
+import { Extract as ZipExtract } from 'unzip-stream'
+import { promisify } from 'util'
+import { addToPath, setEnv } from '../windows'
+import { INSTALL_DIR } from '../constants'
+
+const finishedPromise = promisify(finished)
+
+const ESP_TOOL = 'https://github.com/igrr/esptool-ck/releases/download/0.4.13/esptool-0.4.13-win32.zip'
+const ESP_TOOL_VERSION = 'esptool-0.4.13-win32'
+const CYGWIN = 'https://www.moddable.com/private/cygwin.win32.zip'
+
+export async function installPython(spinner: ReturnType<GluegunPrint['spin']>) {
+    if (system.which('python') === null) {
+        // For some reason, system.which does not work with winget. This is a workaround for now.
+        let foundWinget = true
+        try {
+            await system.exec('where winget')
+        } catch (error) {
+            foundWinget = false
+        }
+
+        if (foundWinget) {
+            spinner.start('Installing python from winget')
+            await system.exec('winget install -e --id Python.Python.3 --silent')
+            spinner.succeed()
+            print.info('Python successfully installed. Please close this window and launch a new Moddable Command Prompt to refresh environment variables, then re-run this setup.')
+            throw new Error("Command Prompt restart needed")
+        } else {
+            print.error('Python is required.')
+            print.info('You can download and install Python from python.org/downloads')
+            print.info('Or xs-dev can manage installing Python and other dependencies using the Windows Package Manager Client (winget).')
+            print.info('You can install winget via the App Installer package in the Microsoft Store.')
+            print.info('Please install either Python or winget, then launch a new Command Prompt and re-run this setup.')
+            throw new Error("Python is required")
+        }
+    }
+}
+
+export async function installDeps(
+  spinner: ReturnType<GluegunPrint['spin']>,
+  ESP_DIR: string
+): Promise<void> {
+    const ESP_TOOL_DIR = filesystem.resolve(ESP_DIR, ESP_TOOL_VERSION)
+    const ESP_TOOL_EXE = filesystem.resolve(ESP_TOOL_DIR, 'esptool.exe')
+    const ESP_TOOL_DESTINATION = filesystem.resolve(ESP_DIR, 'esptool.exe')
+    const CYGWIN_BIN = filesystem.resolve(ESP_DIR, "cygwin", "bin")
+
+    spinner.start('Downloading ESP Tool')
+    let writer = ZipExtract({path: ESP_DIR})
+    let response = await axios.get(ESP_TOOL, {
+        responseType: 'stream'
+    })
+    response.data.pipe(writer)
+    await finishedPromise(writer)
+    filesystem.move(ESP_TOOL_EXE, ESP_TOOL_DESTINATION, {overwrite: true})
+    filesystem.remove(ESP_TOOL_DIR)
+    spinner.succeed()
+
+    spinner.start('Downloading Cygwin toolchain support package')
+    writer = ZipExtract({path: ESP_DIR})
+    response = await axios.get(CYGWIN, {
+        responseType: 'stream'
+    })
+    response.data.pipe(writer)
+    await finishedPromise(writer)
+    spinner.succeed()
+
+    spinner.start('Setting environment variables')
+    await setEnv("BASE_DIR", INSTALL_DIR)
+    await addToPath(CYGWIN_BIN)
+    spinner.succeed()
+
+    try {
+        await installPython(spinner)
+    } catch (error) { // Command Prompt restart needed
+        process.exit(1)
+    }
+    
+    if (system.which('pip') === null) {
+        spinner.start('Installing pip through ensurepip')
+        await system.exec('python -m ensurepip')
+        spinner.succeed()
+    }
+    
+    spinner.start('Installing pyserial through pip')
+    await system.exec('python -m pip install pyserial')
+    spinner.succeed()
+}

--- a/src/toolbox/setup/esp8266/windows.ts
+++ b/src/toolbox/setup/esp8266/windows.ts
@@ -16,20 +16,9 @@ const CYGWIN = 'https://www.moddable.com/private/cygwin.win32.zip'
 export async function installPython(spinner: ReturnType<GluegunPrint['spin']>) {
     if (system.which('python') === null) {
         // For some reason, system.which does not work with winget. This is a workaround for now.
-        let foundWinget = true
         try {
             await system.exec('where winget')
         } catch (error) {
-            foundWinget = false
-        }
-
-        if (foundWinget) {
-            spinner.start('Installing python from winget')
-            await system.exec('winget install -e --id Python.Python.3 --silent')
-            spinner.succeed()
-            print.info('Python successfully installed. Please close this window and launch a new Moddable Command Prompt to refresh environment variables, then re-run this setup.')
-            throw new Error("Command Prompt restart needed")
-        } else {
             print.error('Python is required.')
             print.info('You can download and install Python from python.org/downloads')
             print.info('Or xs-dev can manage installing Python and other dependencies using the Windows Package Manager Client (winget).')
@@ -37,6 +26,12 @@ export async function installPython(spinner: ReturnType<GluegunPrint['spin']>) {
             print.info('Please install either Python or winget, then launch a new Command Prompt and re-run this setup.')
             throw new Error("Python is required")
         }
+        
+        spinner.start('Installing python from winget')
+        await system.exec('winget install -e --id Python.Python.3 --silent')
+        spinner.succeed()
+        print.info('Python successfully installed. Please close this window and launch a new Moddable Command Prompt to refresh environment variables, then re-run this setup.')
+        throw new Error("Command Prompt restart needed")
     }
 }
 

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -60,9 +60,6 @@ export default async function (): Promise<void> {
     'win'
   )
 
-  const spinner = print.spin()
-  spinner.start('Beginning setup...')
-
   print.info(`Setting up Windows tools at ${INSTALL_PATH}`)
 
   // 0. Check for Visual Studio CMD tools & Git
@@ -79,10 +76,18 @@ export default async function (): Promise<void> {
         process.exit(1)
       }
 
-    spinner.start('Installing Visual Studio 2022 Community from winget')
-    await system.exec('winget install -e --id Microsoft.VisualStudio.2022.Community --silent')
-    spinner.succeed()
-    print.info('Visual Studio 2022 Community successfully installed. Please close this window and launch the x86 Native Tools Command Prompt for VS 2022, then re-run this setup.')
+    print.info('Installing Visual Studio 2022 Community from winget...')
+    try {
+        await system.exec('winget install -e --id Microsoft.VisualStudio.2022.Community --silent', {stdio: 'inherit', shell: true})    
+    } catch (error) {
+        print.error('Visual Studio 2022 Community install failed')
+        process.exit(1)
+    }
+    
+    print.info('Visual Studio 2022 Community successfully installed.')
+    print.info('The "Desktop development for C++" workload must be manually installed.')
+    print.info('From your Start Menu, select Visual Studio Installer. Then "Modify." Then select "Desktop development with C++" Then "Modify" again.')
+    print.info('When complete, please close this window and launch the "x86 Native Tools Command Prompt for VS 2022" from the start menu.')
     process.exit(1)
   }
 
@@ -98,13 +103,19 @@ export default async function (): Promise<void> {
       process.exit(1)
     }
     
-    spinner.start('Installing git from winget')
-    await system.exec('winget install -e --id Git.Git --silent')
-    spinner.succeed()
+    print.info('Installing git from winget...')
+    try {
+        await system.exec('winget install -e --id Git.Git --silent', {stdio: 'inherit', shell: true})    
+    } catch (error) {
+        print.error('git install failed')
+        process.exit(1)
+    }
+
     print.info('git successfully installed. Please close this window and re-launch the x86 Native Tools Command Prompt for VS 2022, then re-run this setup.')
     process.exit(1)
   }
 
+  const spinner = print.spin()
   await upsert(EXPORTS_FILE_PATH, '@echo off')
 
   const vsBatPath = filesystem.resolve(process.env.VSINSTALLDIR, "VC", "Auxiliary", "Build", "vcvars32.bat")

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -1,5 +1,128 @@
-import { print } from 'gluegun'
+import { 
+  print,
+  filesystem, 
+  system 
+} from 'gluegun'
+import {
+  INSTALL_PATH,
+  INSTALL_DIR,
+  MODDABLE_REPO,
+  EXPORTS_FILE_PATH
+} from './constants'
+import upsert from '../patching/upsert'
+import ws from 'windows-shortcuts'
+import { promisify } from 'util'
+
+const wsPromise = promisify(ws.create)
+
+const SHORTCUT = filesystem.resolve(INSTALL_DIR, "Moddable Command Prompt.lnk")
+
+export async function setEnv(name: string, permanentValue: string, envValue?: string): Promise<void> {
+  await upsert(EXPORTS_FILE_PATH, `set "${name}=${permanentValue}"`)
+  process.env[name] = envValue !== undefined ? envValue : permanentValue
+}
+
+export async function addToPath(path: string): Promise<void> {
+  const newPath = path + ";" + process.env.PATH
+  await setEnv("PATH", `${path};%PATH%`, newPath)
+}
 
 export default async function (): Promise<void> {
-  print.warning('Windows setup is not currently supported')
+  const BIN_PATH = filesystem.resolve(
+    INSTALL_PATH,
+    'build',
+    'bin',
+    'win',
+    'release'
+  )
+  const BUILD_DIR = filesystem.resolve(
+    INSTALL_PATH,
+    'build',
+    'makefiles',
+    'win'
+  )
+
+  print.info(`Setting up Windows tools at ${INSTALL_PATH}`)
+
+  // 0. Check for Visual Studio CMD tools
+    if (system.which('nmake') === null || process.env.VSINSTALLDIR == undefined) {
+    print.error('Visual Studio 2022 Community is required to build the Moddable SDK: https://www.visualstudio.com/downloads/')
+    print.error('If you already have VS 2022 Community installed, please run "xs-dev setup" from the x86 Native Tools Command Prompt for VS 2022')
+    process.exit(1)
+  }
+  if (system.which('git') === null) {
+    print.error(
+      'git is required to clone the Moddable SDK: https://git-scm.com/download/win'
+    )
+    process.exit(1)
+  }
+
+  await upsert(EXPORTS_FILE_PATH, '@echo off')
+
+  const vsBatPath = filesystem.resolve(process.env.VSINSTALLDIR, "VC", "Auxiliary", "Build", "vcvars32.bat")
+  await upsert(EXPORTS_FILE_PATH, `call "${vsBatPath}"`)
+  
+  const spinner = print.spin()
+  spinner.start('Beginning setup...')
+
+  // 1. clone moddable repo into INSTALL_DIR directory if it does not exist yet
+  try {
+    filesystem.dir(INSTALL_DIR)
+  } catch (error) {
+    spinner.fail(`Error setting up install directory: ${String(error)}`)
+    process.exit(1)
+  }
+
+  if (filesystem.exists(INSTALL_PATH) !== false) {
+    spinner.info('Moddable repo already installed')
+  } else {
+    try {
+      spinner.start('Cloning Moddable-OpenSource/moddable repo')
+      await system.spawn(`git clone ${MODDABLE_REPO} ${INSTALL_PATH}`)
+      spinner.succeed()
+    } catch (error) {
+      spinner.fail(`Error cloning moddable repo: ${String(error)}`)
+      process.exit(1)
+    }
+  }
+
+  // 2. configure MODDABLE env variable, add release binaries dir to PATH
+  spinner.start(`Creating Moddable SDK Environment Batch File`)
+  try {
+    await setEnv('MODDABLE', INSTALL_PATH)
+    await addToPath(BIN_PATH)
+    await setEnv('ISMODDABLECOMMANDPROMPT', '1')
+    spinner.succeed()
+  } catch (error) {
+    spinner.fail(error.toString())
+  }
+
+  // 3. build tools
+  try {
+    spinner.start(`Building Moddable SDK tools`)
+    await system.exec(`build.bat`, { cwd: BUILD_DIR, stdout: process.stdout})
+    spinner.succeed()
+  } catch (error) {
+    spinner.fail(`Error building Moddable SDK tools: ${String(error)}`)
+    process.exit(1)
+  }
+
+  // 4. create Windows shortcut
+  try {
+    spinner.start(`Creating Moddable Command Prompt Shortcut`)
+    await wsPromise(SHORTCUT, {
+      target: '^%comspec^%',
+      args: `/k ${EXPORTS_FILE_PATH}`,
+      workingDir: `${INSTALL_PATH}`,
+      desc: "Moddable Command Prompt"
+    })
+    spinner.succeed()
+  } catch (error) {
+    spinner.fail('Error creating Moddable Command Prompt shortcut')
+  }
+  
+  spinner.succeed("Moddable SDK successfully set up!")
+  print.info(`A shortcut to the Moddable Command Prompt has been created at ${SHORTCUT}.`)
+  print.info('Please close this Command Prompt and then use the shortcut to open a new Moddable Command Prompt. You should always use the Moddable Command Prompt when working with the Moddable SDK.')
+  print.info(`As a next step, try running the "helloworld example" in the Moddable Command Prompt: xs-dev run --example helloworld'`)
 }


### PR DESCRIPTION
This commit includes a rework of Windows support for xs-dev + initial Windows support for the ESP8266 and ESP32. In the spirit of always throwing away the first draft of a project, this PR replaces the work in #44. 

The differences between this PR and #44 are:

- No longer modify the User's permanent environment variables / registry
   - Instead, manage environment setup through a batch file that must be invoked in new Command Prompt instances (`Moddable.bat`) which is created by `xs-dev setup`
   - `Moddable.bat` runs the VS 2022 environment setup batch file, the ESP-IDF environment setup batch file (if needed), sets Moddable environment variables, etc.
   - `xs-dev setup` also creates a Windows Shortcut that opens a Command Prompt and automatically invokes `Moddable.bat`. This "Moddable Command Prompt" should be used for all xs-dev/Moddable SDK sessions after setup
- Added initial support for ESP8266 and ESP32 on Windows
   - `xs-dev setup` and `xs-dev run` work with  `--device=esp8266` and `device=esp32`
   - There seems to be an issue at the moment with the certificate used by moddable.com that is causing some issues with the download of ESP8266 pieces