### PR TITLE
feat(update): use v4.4.2 tag of esp-idf

### DIFF
--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -9,7 +9,7 @@ import { installDeps as installLinuxDeps } from './esp32/linux'
 export default async function (): Promise<void> {
   const OS = platformType().toLowerCase()
   const ESP_IDF_REPO = 'https://github.com/espressif/esp-idf.git'
-  const ESP_BRANCH = 'v4.4'
+  const ESP_BRANCH = 'v4.4.2'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
 

--- a/src/toolbox/update/esp32.ts
+++ b/src/toolbox/update/esp32.ts
@@ -8,7 +8,7 @@ import { installDeps as installLinuxDeps } from '../setup/esp32/linux'
 
 export default async function (): Promise<void> {
   const OS = platformType().toLowerCase()
-  const ESP_BRANCH = 'v4.4'
+  const ESP_BRANCH = 'v4.4.2'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
 


### PR DESCRIPTION
The Moddable SDK will be updating to use ESP-IDF v4.4.2 shortly. I'm getting the same move staged here while I'm updating files in the Moddable SDK.

I'll flip this out of draft when the Moddable SDK change goes live to GitHub.