### PR TITLE
feat(setup): add target-branch option, pull latest release by default

### DIFF
--- a/bin/xs-dev
+++ b/bin/xs-dev
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-
 /* tslint:disable */
 // check if we're running in dev mode
 var devMode = require('fs').existsSync(`${__dirname}/../src`)
@@ -13,9 +12,9 @@ if (wantsCompiled || !devMode) {
 } else {
   // this runs from the typescript source (for dev only)
   // hook into ts-node so we can run typescript on the fly
-  require('ts-node').register({ project: `${__dirname}/../tsconfig.json` })
+  require('ts-node').register({
+    project: `${__dirname}/../tsconfig.json`,
+  })
   // run the CLI with the current process arguments
   require(`${__dirname}/../src/cli`).run(process.argv)
 }
-
-

--- a/docs/src/pages/en/features/setup.md
+++ b/docs/src/pages/en/features/setup.md
@@ -6,7 +6,7 @@ layout: ../../../layouts/MainLayout.astro
 
 # Moddable Platform Setup
 
-This command downloads and builds the [Moddable developer tooling](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/tools/tools.md) for the current OS (Windows support coming soon).
+This command downloads the [Moddable developer tooling](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/tools/tools.md) for the current OS (Windows support coming soon).
 
 [After installing the CLI](/en/introduction#installation), call the `setup` command:
 
@@ -27,6 +27,18 @@ A symlink for [`xsbug.app`](https://github.com/Moddable-OpenSource/moddable/blob
 **On Unix environments:**
 
 The [`moddable` git repo](https://github.com/Moddable-OpenSource/moddable) is cloned into `~/.local/share` instead of a new/existing `~/Projects` directory.
+
+## Target Branch
+
+The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 
+
+To override this behavior, use the `--target-branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools.
+
+```
+xs-dev setup --target-branch public
+```
+
+_This will only work for the `mac`, `windows`, and `linux` device options, which are the respective defaults for the operating system on which the command is run._
 
 ## Device Setup
 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -11,8 +11,6 @@
     "isolatedModules": true,
     "noEmit": true,
     // Add type definitions for our Vite runtime.
-    "types": [
-      "vite/client"
-    ]
+    "types": ["vite/client"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "url": "https://github.com/HipsterBrown/xs-dev.git"
   },
   "dependencies": {
+    "@octokit/rest": "^19.0.3",
     "axios": "^0.24.0",
     "gluegun": "^5.0.0",
     "serialport": "^10.3.0",
@@ -76,7 +77,7 @@
     "preact-render-to-string": "^5.2.0",
     "prettier": "^2.5.1",
     "ts-jest": "^27.1.0",
-    "ts-node": "^10.4.0",
+    "ts-node": "^10.9.1",
     "typescript": "^4.7.3"
   },
   "jest": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ specifiers:
   '@astrojs/sitemap': ^1.0.0
   '@astrojs/tailwind': ^1.0.0
   '@changesets/cli': ^2.19.0
+  '@octokit/rest': ^19.0.3
   '@types/jest': ^27.4.0
   '@types/node': ^16.11.0
   '@types/serve-handler': ^6.1.1
@@ -33,12 +34,13 @@ specifiers:
   serve-handler: ^6.1.3
   tar-fs: ^2.1.1
   ts-jest: ^27.1.0
-  ts-node: ^10.4.0
+  ts-node: ^10.9.1
   typescript: ^4.7.3
   unzip-stream: ^0.3.1
   usb: ^2.2.0
 
 dependencies:
+  '@octokit/rest': 19.0.3
   axios: 0.24.0
   gluegun: 5.0.0
   serialport: 10.3.0
@@ -51,7 +53,7 @@ devDependencies:
   '@astrojs/lit': 1.0.0_7n7v3zkrh6saiovzbqgoobmfte
   '@astrojs/preact': 1.0.1_preact@10.7.3
   '@astrojs/sitemap': 1.0.0
-  '@astrojs/tailwind': 1.0.0_ts-node@10.4.0
+  '@astrojs/tailwind': 1.0.0_ts-node@10.9.1
   '@changesets/cli': 2.19.0
   '@types/jest': 27.4.0
   '@types/node': 16.11.19
@@ -61,7 +63,7 @@ devDependencies:
   '@typescript-eslint/eslint-plugin': 4.33.0_b2rfmdvuwe4rokpupduzboofj4
   '@typescript-eslint/parser': 4.33.0_kix3shd7zvxuvkzdjm72bpp2vy
   '@webcomponents/template-shadowroot': 0.1.0
-  astro: 1.0.2_ts-node@10.4.0
+  astro: 1.0.2_ts-node@10.9.1
   eslint: 7.32.0
   eslint-config-prettier: 8.3.0_eslint@7.32.0
   eslint-config-standard-with-typescript: 21.0.1_pth4wrlyl4g4syggzyakmfinj4
@@ -69,13 +71,13 @@ devDependencies:
   eslint-plugin-node: 11.1.0_eslint@7.32.0
   eslint-plugin-promise: 5.2.0_eslint@7.32.0
   fuse.js: 6.6.2
-  jest: 27.4.7_ts-node@10.4.0
+  jest: 27.4.7_ts-node@10.9.1
   lit: 2.2.5
   preact: 10.7.3
   preact-render-to-string: 5.2.0_preact@10.7.3
   prettier: 2.5.1
   ts-jest: 27.1.2_phpi45bkmqo24qpn6me32war5i
-  ts-node: 10.4.0_pf6wn77ptdzjivnbizhsgg36ee
+  ts-node: 10.9.1_pf6wn77ptdzjivnbizhsgg36ee
   typescript: 4.7.3
 
 packages:
@@ -85,7 +87,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.15
     dev: true
 
   /@astrojs/compiler/0.23.1:
@@ -192,13 +194,13 @@ packages:
       zod: 3.17.3
     dev: true
 
-  /@astrojs/tailwind/1.0.0_ts-node@10.4.0:
+  /@astrojs/tailwind/1.0.0_ts-node@10.9.1:
     resolution: {integrity: sha512-hEpvKBJKCStaxRZt3ENDacQlzUTOvW1D7dfIUyTf7jMUK4O+y8Q7gdTjERf1HBEi/YXrYNX1zhAElwp6lvW5oQ==}
     dependencies:
       '@proload/core': 0.3.2
       autoprefixer: 10.4.7_postcss@8.4.14
       postcss: 8.4.14
-      tailwindcss: 3.0.24_ts-node@10.4.0
+      tailwindcss: 3.0.24_ts-node@10.9.1
     transitivePeerDependencies:
       - ts-node
     dev: true
@@ -898,16 +900,11 @@ packages:
       prettier: 1.19.1
     dev: true
 
-  /@cspotcode/source-map-consumer/0.8.0:
-    resolution: {integrity: sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==}
-    engines: {node: '>= 12'}
-    dev: true
-
-  /@cspotcode/source-map-support/0.7.0:
-    resolution: {integrity: sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==}
+  /@cspotcode/source-map-support/0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
     dependencies:
-      '@cspotcode/source-map-consumer': 0.8.0
+      '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
   /@emmetio/abbreviation/2.2.3:
@@ -995,7 +992,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core/27.4.7_ts-node@10.4.0:
+  /@jest/core/27.4.7_ts-node@10.9.1:
     resolution: {integrity: sha512-n181PurSJkVMS+kClIFSX/LLvw9ExSb+4IMtD6YnfxZVerw9ANYtW0bPrm0MJu2pfe9SY9FJ9FtQ+MdZkrZwjg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
@@ -1016,7 +1013,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.9
       jest-changed-files: 27.4.2
-      jest-config: 27.4.7_ts-node@10.4.0
+      jest-config: 27.4.7_ts-node@10.9.1
       jest-haste-map: 27.4.6
       jest-message-util: 27.4.6
       jest-regex-util: 27.4.0
@@ -1179,7 +1176,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.1
-      '@jridgewell/sourcemap-codec': 1.4.13
+      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /@jridgewell/gen-mapping/0.3.1:
@@ -1187,12 +1184,12 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.1
-      '@jridgewell/sourcemap-codec': 1.4.13
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/trace-mapping': 0.3.15
     dev: true
 
-  /@jridgewell/resolve-uri/3.0.7:
-    resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
     dev: true
 
@@ -1201,15 +1198,22 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: true
 
-  /@jridgewell/sourcemap-codec/1.4.13:
-    resolution: {integrity: sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==}
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
     dev: true
 
-  /@jridgewell/trace-mapping/0.3.13:
-    resolution: {integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==}
+  /@jridgewell/trace-mapping/0.3.15:
+    resolution: {integrity: sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.0.7
-      '@jridgewell/sourcemap-codec': 1.4.13
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /@lit-labs/ssr-client/1.0.1:
@@ -1285,6 +1289,122 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
     dev: true
+
+  /@octokit/auth-token/3.0.0:
+    resolution: {integrity: sha512-MDNFUBcJIptB9At7HiV7VCvU3NcL4GnfCQaP8C5lrxWrRPMJBnemYtehaKSOlaM7AYxeRyj9etenu8LVpSpVaQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/types': 6.41.0
+    dev: false
+
+  /@octokit/core/4.0.4:
+    resolution: {integrity: sha512-sUpR/hc4Gc7K34o60bWC7WUH6Q7T6ftZ2dUmepSyJr9PRF76/qqkWjE2SOEzCqLA5W83SaISymwKtxks+96hPQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/auth-token': 3.0.0
+      '@octokit/graphql': 5.0.0
+      '@octokit/request': 6.2.0
+      '@octokit/request-error': 3.0.0
+      '@octokit/types': 6.41.0
+      before-after-hook: 2.2.2
+      universal-user-agent: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@octokit/endpoint/7.0.0:
+    resolution: {integrity: sha512-Kz/mIkOTjs9rV50hf/JK9pIDl4aGwAtT8pry6Rpy+hVXkAPhXanNQRxMoq6AeRgDCZR6t/A1zKniY2V1YhrzlQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/types': 6.41.0
+      is-plain-object: 5.0.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/graphql/5.0.0:
+    resolution: {integrity: sha512-1ZZ8tX4lUEcLPvHagfIVu5S2xpHYXAmgN0+95eAOPoaVPzCfUXJtA5vASafcpWcO86ze0Pzn30TAx72aB2aguQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/request': 6.2.0
+      '@octokit/types': 6.41.0
+      universal-user-agent: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@octokit/openapi-types/12.11.0:
+    resolution: {integrity: sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==}
+    dev: false
+
+  /@octokit/plugin-paginate-rest/3.1.0_@octokit+core@4.0.4:
+    resolution: {integrity: sha512-+cfc40pMzWcLkoDcLb1KXqjX0jTGYXjKuQdFQDc6UAknISJHnZTiBqld6HDwRJvD4DsouDKrWXNbNV0lE/3AXA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      '@octokit/core': '>=4'
+    dependencies:
+      '@octokit/core': 4.0.4
+      '@octokit/types': 6.41.0
+    dev: false
+
+  /@octokit/plugin-request-log/1.0.4_@octokit+core@4.0.4:
+    resolution: {integrity: sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==}
+    peerDependencies:
+      '@octokit/core': '>=3'
+    dependencies:
+      '@octokit/core': 4.0.4
+    dev: false
+
+  /@octokit/plugin-rest-endpoint-methods/6.2.0_@octokit+core@4.0.4:
+    resolution: {integrity: sha512-PZ+yfkbZAuRUtqu6Y191/V3eM0KBPx+Yq7nh+ONPdpm3EX4pd5UnK2y2XgO/0AtNum5a4aJCDjqsDuUZ2hWRXw==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      '@octokit/core': '>=3'
+    dependencies:
+      '@octokit/core': 4.0.4
+      '@octokit/types': 6.41.0
+      deprecation: 2.3.1
+    dev: false
+
+  /@octokit/request-error/3.0.0:
+    resolution: {integrity: sha512-WBtpzm9lR8z4IHIMtOqr6XwfkGvMOOILNLxsWvDwtzm/n7f5AWuqJTXQXdDtOvPfTDrH4TPhEvW2qMlR4JFA2w==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/types': 6.41.0
+      deprecation: 2.3.1
+      once: 1.4.0
+    dev: false
+
+  /@octokit/request/6.2.0:
+    resolution: {integrity: sha512-7IAmHnaezZrgUqtRShMlByJK33MT9ZDnMRgZjnRrRV9a/jzzFwKGz0vxhFU6i7VMLraYcQ1qmcAOin37Kryq+Q==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/endpoint': 7.0.0
+      '@octokit/request-error': 3.0.0
+      '@octokit/types': 6.41.0
+      is-plain-object: 5.0.0
+      node-fetch: 2.6.7
+      universal-user-agent: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@octokit/rest/19.0.3:
+    resolution: {integrity: sha512-5arkTsnnRT7/sbI4fqgSJ35KiFaN7zQm0uQiQtivNQLI8RQx8EHwJCajcTUwmaCMNDg7tdCvqAnc7uvHHPxrtQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/core': 4.0.4
+      '@octokit/plugin-paginate-rest': 3.1.0_@octokit+core@4.0.4
+      '@octokit/plugin-request-log': 1.0.4_@octokit+core@4.0.4
+      '@octokit/plugin-rest-endpoint-methods': 6.2.0_@octokit+core@4.0.4
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@octokit/types/6.41.0:
+    resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
+    dependencies:
+      '@octokit/openapi-types': 12.11.0
+    dev: false
 
   /@polka/url/1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
@@ -2007,7 +2127,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /astro/1.0.2_ts-node@10.4.0:
+  /astro/1.0.2_ts-node@10.9.1:
     resolution: {integrity: sha512-7Bmw8wGQnh/rRpybc6owYbAyr6SXKm7kX56gg82ABJbqnTQhbgOPtg8+k+KKkJekMU/gPe3LfMIh0+Ie+F9xUw==}
     engines: {node: ^14.18.0 || >=16.12.0, npm: '>=6.14.0'}
     hasBin: true
@@ -2047,7 +2167,7 @@ packages:
       path-browserify: 1.0.1
       path-to-regexp: 6.2.1
       postcss: 8.4.14
-      postcss-load-config: 3.1.4_vj5zvfoxav3uugaoxwvp62x5qu
+      postcss-load-config: 3.1.4_pe6iykxod2v7i2uk6okjazxzki
       preferred-pm: 3.0.3
       prompts: 2.4.2
       recast: 0.20.5
@@ -2209,6 +2329,10 @@ packages:
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  /before-after-hook/2.2.2:
+    resolution: {integrity: sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==}
+    dev: false
 
   /better-path-resolve/1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -2796,6 +2920,10 @@ packages:
     resolution: {integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=}
     engines: {node: '>=0.4.0'}
     dev: true
+
+  /deprecation/2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+    dev: false
 
   /dequal/2.0.2:
     resolution: {integrity: sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==}
@@ -4586,6 +4714,11 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /is-plain-object/5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-potential-custom-element-name/1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
     dev: true
@@ -4759,7 +4892,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/27.4.7_ts-node@10.4.0:
+  /jest-cli/27.4.7_ts-node@10.9.1:
     resolution: {integrity: sha512-zREYhvjjqe1KsGV15mdnxjThKNDgza1fhDT+iUsXWLCq3sxe9w5xnvyctcYVT5PcdLSjv7Y5dCwTS3FCF1tiuw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -4769,14 +4902,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 27.4.7_ts-node@10.4.0
+      '@jest/core': 27.4.7_ts-node@10.9.1
       '@jest/test-result': 27.4.6
       '@jest/types': 27.4.2
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.9
       import-local: 3.1.0
-      jest-config: 27.4.7_ts-node@10.4.0
+      jest-config: 27.4.7_ts-node@10.9.1
       jest-util: 27.4.2
       jest-validate: 27.4.6
       prompts: 2.4.2
@@ -4789,7 +4922,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-config/27.4.7_ts-node@10.4.0:
+  /jest-config/27.4.7_ts-node@10.9.1:
     resolution: {integrity: sha512-xz/o/KJJEedHMrIY9v2ParIoYSrSVY6IVeE4z5Z3i101GoA5XgfbJz+1C8EYPsv7u7f39dS8F9v46BHDhn0vlw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
@@ -4820,7 +4953,7 @@ packages:
       micromatch: 4.0.4
       pretty-format: 27.4.6
       slash: 3.0.0
-      ts-node: 10.4.0_pf6wn77ptdzjivnbizhsgg36ee
+      ts-node: 10.9.1_pf6wn77ptdzjivnbizhsgg36ee
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -5168,7 +5301,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/27.4.7_ts-node@10.4.0:
+  /jest/27.4.7_ts-node@10.9.1:
     resolution: {integrity: sha512-8heYvsx7nV/m8m24Vk26Y87g73Ba6ueUd0MWed/NXMhSZIm62U/llVbS0PJe1SHunbyXjJ/BqG1z9bFjGUIvTg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -5178,9 +5311,9 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 27.4.7_ts-node@10.4.0
+      '@jest/core': 27.4.7_ts-node@10.9.1
       import-local: 3.1.0
-      jest-cli: 27.4.7_ts-node@10.4.0
+      jest-cli: 27.4.7_ts-node@10.9.1
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -6164,7 +6297,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
   /node-fetch/3.2.5:
     resolution: {integrity: sha512-u7zCHdJp8JXBwF09mMfo2CL6kp37TslDl1KP3hRGTlCInBtag+UO3LGVy+NF0VzvnL3PVMpA2hXh1EtECFnyhQ==}
@@ -6564,7 +6696,7 @@ packages:
       postcss: 8.4.14
     dev: true
 
-  /postcss-load-config/3.1.4_vj5zvfoxav3uugaoxwvp62x5qu:
+  /postcss-load-config/3.1.4_pe6iykxod2v7i2uk6okjazxzki:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -6578,7 +6710,7 @@ packages:
     dependencies:
       lilconfig: 2.0.5
       postcss: 8.4.14
-      ts-node: 10.4.0_pf6wn77ptdzjivnbizhsgg36ee
+      ts-node: 10.9.1_pf6wn77ptdzjivnbizhsgg36ee
       yaml: 1.10.2
     dev: true
 
@@ -7512,7 +7644,7 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwindcss/3.0.24_ts-node@10.4.0:
+  /tailwindcss/3.0.24_ts-node@10.9.1:
     resolution: {integrity: sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==}
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -7532,7 +7664,7 @@ packages:
       picocolors: 1.0.0
       postcss: 8.4.14
       postcss-js: 4.0.0_postcss@8.4.14
-      postcss-load-config: 3.1.4_vj5zvfoxav3uugaoxwvp62x5qu
+      postcss-load-config: 3.1.4_pe6iykxod2v7i2uk6okjazxzki
       postcss-nested: 5.0.6_postcss@8.4.14
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
@@ -7638,7 +7770,6 @@ packages:
 
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
 
   /tr46/2.1.0:
     resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
@@ -7684,7 +7815,7 @@ packages:
       '@types/jest': 27.4.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.4.7_ts-node@10.4.0
+      jest: 27.4.7_ts-node@10.9.1
       jest-util: 27.4.2
       json5: 2.2.0
       lodash.memoize: 4.1.2
@@ -7694,8 +7825,8 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-node/10.4.0_pf6wn77ptdzjivnbizhsgg36ee:
-    resolution: {integrity: sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==}
+  /ts-node/10.9.1_pf6wn77ptdzjivnbizhsgg36ee:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
@@ -7708,7 +7839,7 @@ packages:
       '@swc/wasm':
         optional: true
     dependencies:
-      '@cspotcode/source-map-support': 0.7.0
+      '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.8
       '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
@@ -7721,6 +7852,7 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 4.7.3
+      v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
 
@@ -7960,6 +8092,10 @@ packages:
       unist-util-visit-parents: 5.1.0
     dev: true
 
+  /universal-user-agent/6.0.0:
+    resolution: {integrity: sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==}
+    dev: false
+
   /universalify/0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -8000,6 +8136,10 @@ packages:
       diff: 5.1.0
       kleur: 4.1.4
       sade: 1.8.1
+    dev: true
+
+  /v8-compile-cache-lib/3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
 
   /v8-compile-cache/2.3.0:
@@ -8188,7 +8328,6 @@ packages:
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
 
   /webidl-conversions/5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
@@ -8215,7 +8354,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: true
 
   /whatwg-url/8.7.0:
     resolution: {integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==}

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -8,6 +8,7 @@ interface SetupOptions {
   device?: Device
   listDevices?: boolean
   tool?: string
+  targetBranch?: 'public' | 'latest-release'
 }
 
 const command: GluegunCommand<XSDevToolbox> = {
@@ -20,6 +21,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       device,
       listDevices = false,
       tool,
+      targetBranch = 'latest-release',
     }: SetupOptions = parameters.options
     let target: Device = device ?? currentPlatform
 
@@ -57,7 +59,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       return
     }
 
-    await setup[target]()
+    await setup[target]({ targetBranch })
   },
 }
 

--- a/src/toolbox/setup/linux.ts
+++ b/src/toolbox/setup/linux.ts
@@ -1,3 +1,6 @@
+import os from 'os'
+import { promisify } from 'util'
+import { chmod } from 'fs'
 import { filesystem, print, system } from 'gluegun'
 import {
   INSTALL_DIR,
@@ -9,8 +12,11 @@ import {
 import upsert from '../patching/upsert'
 import { execWithSudo } from '../system/exec'
 import { SetupArgs } from './types'
+import { fetchLatestRelease, downloadReleaseTools } from './moddable'
 
-export default async function (_args: SetupArgs): Promise<void> {
+const chmodPromise = promisify(chmod)
+
+export default async function ({ targetBranch }: SetupArgs): Promise<void> {
   print.info('Setting up Linux tools!')
 
   const BIN_PATH = filesystem.resolve(
@@ -19,6 +25,13 @@ export default async function (_args: SetupArgs): Promise<void> {
     'bin',
     'lin',
     'release'
+  )
+  const DEBUG_BIN_PATH = filesystem.resolve(
+    INSTALL_PATH,
+    'build',
+    'bin',
+    'lin',
+    'debug'
   )
   const BUILD_DIR = filesystem.resolve(
     INSTALL_PATH,
@@ -55,8 +68,43 @@ export default async function (_args: SetupArgs): Promise<void> {
   if (filesystem.exists(INSTALL_PATH) !== false) {
     spinner.info('Moddable repo already installed')
   } else {
-    spinner.start('Cloning Moddable-OpenSource/moddable repo')
-    await system.spawn(`git clone ${MODDABLE_REPO} ${INSTALL_PATH}`)
+    if (targetBranch === 'latest-release') {
+      spinner.start('Getting latest Moddable-OpenSource/moddable release')
+      const release = await fetchLatestRelease()
+      await system.spawn(
+        `git clone ${MODDABLE_REPO} ${INSTALL_PATH} --depth 1 --branch ${release.tag_name} --single-branch`
+      )
+
+      filesystem.dir(BIN_PATH)
+      filesystem.dir(DEBUG_BIN_PATH)
+
+      const isArm = os.arch() === 'arm64'
+      const assetName = isArm
+        ? 'moddable-tools-lin64arm.zip'
+        : 'moddable-tools-lin64.zip'
+      spinner.info('Downloading release tools')
+      await downloadReleaseTools({
+        writePath: BIN_PATH,
+        assetName,
+        release,
+      })
+      const tools = filesystem.list(BIN_PATH) ?? []
+      await Promise.all(
+        tools.map(async (tool) => {
+          await chmodPromise(filesystem.resolve(BIN_PATH, tool), 0o751)
+          await filesystem.copyAsync(
+            filesystem.resolve(BIN_PATH, tool),
+            filesystem.resolve(DEBUG_BIN_PATH, tool)
+          )
+        })
+      )
+    }
+    if (targetBranch === 'public') {
+      spinner.start('Cloning Moddable-OpenSource/moddable repo')
+      await system.spawn(
+        `git clone ${MODDABLE_REPO} ${INSTALL_PATH} --depth 1 --branch ${targetBranch} --single-branch`
+      )
+    }
     spinner.succeed()
   }
 
@@ -70,9 +118,11 @@ export default async function (_args: SetupArgs): Promise<void> {
   await upsert(EXPORTS_FILE_PATH, `export PATH="${BIN_PATH}:$PATH"`)
 
   // 5. Build the Moddable command line tools, simulator, and debugger from the command line:
-  spinner.start('Building platform tooling')
-  await system.exec('make', { cwd: BUILD_DIR, stdout: process.stdout })
-  spinner.succeed()
+  if (targetBranch === 'public') {
+    spinner.start('Building platform tooling')
+    await system.exec('make', { cwd: BUILD_DIR, stdout: process.stdout })
+    spinner.succeed()
+  }
 
   // 6. Install the desktop simulator and xsbug debugger applications
   spinner.start('Installing simulator')

--- a/src/toolbox/setup/linux.ts
+++ b/src/toolbox/setup/linux.ts
@@ -8,8 +8,9 @@ import {
 } from './constants'
 import upsert from '../patching/upsert'
 import { execWithSudo } from '../system/exec'
+import { SetupArgs } from './types'
 
-export default async function (): Promise<void> {
+export default async function (_args: SetupArgs): Promise<void> {
   print.info('Setting up Linux tools!')
 
   const BIN_PATH = filesystem.resolve(

--- a/src/toolbox/setup/linux.ts
+++ b/src/toolbox/setup/linux.ts
@@ -126,6 +126,37 @@ export default async function ({ targetBranch }: SetupArgs): Promise<void> {
 
   // 6. Install the desktop simulator and xsbug debugger applications
   spinner.start('Installing simulator')
+  if (targetBranch === 'latest-release') {
+    filesystem.dir(
+      filesystem.resolve(
+        BUILD_DIR,
+        '..',
+        '..',
+        'tmp',
+        'lin',
+        'debug',
+        'simulator'
+      )
+    )
+    await system.exec(
+      `mcconfig -m -p x-lin ${filesystem.resolve(
+        INSTALL_PATH,
+        'tools',
+        'xsbug',
+        'manifest.json'
+      )}`,
+      { process }
+    )
+    await system.exec(
+      `mcconfig -m -p x-lin ${filesystem.resolve(
+        INSTALL_PATH,
+        'tools',
+        'mcsim',
+        'manifest.json'
+      )}`,
+      { process }
+    )
+  }
   await execWithSudo('make install', {
     cwd: BUILD_DIR,
     stdout: process.stdout,

--- a/src/toolbox/setup/moddable.ts
+++ b/src/toolbox/setup/moddable.ts
@@ -1,8 +1,62 @@
+import { finished } from 'stream'
+import { promisify } from 'util'
 import { filesystem } from 'gluegun'
+import { Octokit, RestEndpointMethodTypes } from '@octokit/rest'
+import { Extract as ZipExtract } from 'unzip-stream'
+import axios from 'axios'
+
+const finishedPromise = promisify(finished)
 
 export function moddableExists(): boolean {
   return (
     process.env.MODDABLE !== undefined &&
     filesystem.exists(process.env.MODDABLE) === 'dir'
   )
+}
+
+type ExtractFromArray<Item extends readonly unknown[]> = Item extends Readonly<
+  Array<infer ItemType>
+>
+  ? ItemType
+  : never
+type GitHubRelease = ExtractFromArray<
+  RestEndpointMethodTypes['repos']['listReleases']['response']['data']
+>
+
+export async function fetchLatestRelease(): Promise<GitHubRelease> {
+  const octokit = new Octokit()
+  const releases = await octokit.rest.repos.listReleases({
+    owner: 'Moddable-OpenSource',
+    repo: 'moddable',
+    per_page: 1,
+  })
+  const [latestRelease] = releases.data
+  return latestRelease
+}
+
+interface DownloadToolsArgs {
+  writePath: string
+  assetName: string
+  release: GitHubRelease
+}
+
+export async function downloadReleaseTools({
+  writePath,
+  assetName,
+  release,
+}: DownloadToolsArgs): Promise<void> {
+  const moddableTools = release.assets.find(({ name }) => name === assetName)
+
+  if (moddableTools === undefined) {
+    throw new Error(`Unable to find release asset matching ${assetName}`)
+  }
+
+  const zipWriter = ZipExtract({
+    path: writePath,
+  })
+  const response = await axios.get(moddableTools.browser_download_url, {
+    responseType: 'stream',
+  })
+  response.data.pipe(zipWriter)
+  await finishedPromise(zipWriter)
 }

--- a/src/toolbox/setup/types.ts
+++ b/src/toolbox/setup/types.ts
@@ -1,0 +1,3 @@
+export interface SetupArgs {
+  targetBranch: 'public' | 'latest-release'
+}

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -1,5 +1,6 @@
 import { print } from 'gluegun'
+import { SetupArgs } from './types'
 
-export default async function (): Promise<void> {
+export default async function (_args: SetupArgs): Promise<void> {
   print.warning('Windows setup is not currently supported')
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { GluegunToolbox } from 'gluegun'
+import { SetupArgs } from './toolbox/setup/types'
 
 export type Device =
   | 'darwin'
@@ -11,6 +12,9 @@ export type Device =
   | 'pico'
 
 export interface XSDevToolbox extends GluegunToolbox {
-  setup: Record<Device, () => Promise<void>>
+  setup: Record<
+    Device,
+    (() => Promise<void>) | ((args: SetupArgs) => Promise<void>)
+  >
   update: Record<Device, () => Promise<void>>
 }


### PR DESCRIPTION
Fixes #24 

Tested on Mac and Linux. This PR avoids building the Moddable tooling during the setup process, using the prebuilt release assets from GitHub and doing a shallow clone of the tagged branch instead. On linux, it is still required to to a bit of the build process to get the desktop applications installed correctly. 

Docs:
<img width="726" alt="Screen Shot 2022-08-15 at 5 48 32 PM" src="https://user-images.githubusercontent.com/3051193/184780802-a85f5b22-cffa-4014-a03f-66724d4fedb6.png">

