### PR TITLE
feat(update): add target-branch option, pull latest release by default

### DIFF
--- a/docs/src/pages/en/features/update.md
+++ b/docs/src/pages/en/features/update.md
@@ -12,6 +12,22 @@ Stay up to date with the latest tooling from Moddable and supported device targe
 xs-dev update
 ```
 
+## Target Branch
+
+The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 
+
+To override this behavior, use the `--target-branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools.
+
+```
+xs-dev setup --target-branch public
+```
+
+_This will only work for the `mac`, `windows`, and `linux` device options, which are the respective defaults for the operating system on which the command is run._
+
+## Device Updates
+
+While the `update` command provides the latest Moddable SDK for the dev environment, the `--device` flag selects another platform target SDK to set up. It ensures the Moddable SDK has been installed first.
+
 The `--device` flag allows for selecting a different target platform:
 
 ```

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -4,6 +4,7 @@ import type { Device, XSDevToolbox } from '../types'
 
 interface UpdateOptions {
   device?: Device
+  targetBranch?: 'public' | 'latest-release'
 }
 
 const command: GluegunCommand<XSDevToolbox> = {
@@ -11,8 +12,11 @@ const command: GluegunCommand<XSDevToolbox> = {
   description: 'Check and update Moddable tooling for various platform targets',
   run: async ({ parameters, update }) => {
     const currentPlatform: Device = platformType().toLowerCase() as Device
-    const { device = currentPlatform }: UpdateOptions = parameters.options
-    await update[device]()
+    const {
+      device = currentPlatform,
+      targetBranch = 'latest-release',
+    }: UpdateOptions = parameters.options
+    await update[device]({ targetBranch })
   },
 }
 

--- a/src/toolbox/setup/moddable.ts
+++ b/src/toolbox/setup/moddable.ts
@@ -25,12 +25,10 @@ type GitHubRelease = ExtractFromArray<
 
 export async function fetchLatestRelease(): Promise<GitHubRelease> {
   const octokit = new Octokit()
-  const releases = await octokit.rest.repos.listReleases({
+  const { data: latestRelease } = await octokit.rest.repos.getLatestRelease({
     owner: 'Moddable-OpenSource',
     repo: 'moddable',
-    per_page: 1,
   })
-  const [latestRelease] = releases.data
   return latestRelease
 }
 

--- a/src/toolbox/update/linux.ts
+++ b/src/toolbox/update/linux.ts
@@ -1,54 +1,178 @@
+import os from 'os'
+import { promisify } from 'util'
+import { chmod } from 'fs'
 import { print, system, filesystem } from 'gluegun'
-import { INSTALL_PATH } from '../setup/constants'
+import { INSTALL_PATH, MODDABLE_REPO } from '../setup/constants'
+import { SetupArgs } from '../setup/types'
+import {
+  fetchLatestRelease,
+  moddableExists,
+  downloadReleaseTools,
+} from '../setup/moddable'
+import { execWithSudo } from '../system/exec'
 
-export default async function (): Promise<void> {
+const chmodPromise = promisify(chmod)
+
+export default async function ({ targetBranch }: SetupArgs): Promise<void> {
+  // 0. ensure Moddable exists
+  if (!moddableExists()) {
+    print.error(
+      'Moddable tooling required. Run `xs-dev setup` before trying again.'
+    )
+    process.exit(1)
+  }
+
   print.info('Checking for SDK changes')
+
   const BUILD_DIR = filesystem.resolve(
     INSTALL_PATH,
     'build',
     'makefiles',
-    'mac'
+    'lin'
   )
 
-  const currentRev: string = await system.exec('git rev-parse public', {
-    cwd: process.env.MODDABLE,
-  })
-  const remoteRev: string = await system.exec(
-    'git ls-remote origin refs/heads/public',
-    { cwd: process.env.MODDABLE }
-  )
+  if (targetBranch === 'latest-release') {
+    // get tag for current repo
+    const currentTag: string = await system.exec('git tag', {
+      cwd: process.env.MODDABLE,
+    })
+    // get latest release tag
+    const latestRelease = await fetchLatestRelease()
 
-  if (remoteRev.split('\t').shift() === currentRev.trim()) {
-    print.success('Moddable SDK already up to date!')
-    process.exit(0)
+    if (currentTag.trim() === latestRelease.tag_name) {
+      print.success('Moddable SDK already up to date!')
+      process.exit(0)
+    }
+
+    const spinner = print.spin()
+    spinner.start('Updating Moddable SDK!')
+
+    const BIN_PATH = filesystem.resolve(
+      INSTALL_PATH,
+      'build',
+      'bin',
+      'lin',
+      'release'
+    )
+    const DEBUG_BIN_PATH = filesystem.resolve(
+      INSTALL_PATH,
+      'build',
+      'bin',
+      'lin',
+      'debug'
+    )
+
+    filesystem.remove(process.env.MODDABLE)
+    await system.spawn(
+      `git clone ${MODDABLE_REPO} ${INSTALL_PATH} --depth 1 --branch ${latestRelease.tag_name} --single-branch`
+    )
+
+    filesystem.dir(BIN_PATH)
+    filesystem.dir(DEBUG_BIN_PATH)
+
+    const isArm = os.arch() === 'arm64'
+    const assetName = isArm
+      ? 'moddable-tools-lin64arm.zip'
+      : 'moddable-tools-lin64.zip'
+
+    spinner.info('Downloading release tools')
+    await downloadReleaseTools({
+      writePath: BIN_PATH,
+      assetName,
+      release: latestRelease,
+    })
+
+    spinner.info('Updating tool permissions')
+    const tools = filesystem.list(BIN_PATH) ?? []
+    await Promise.all(
+      tools.map(async (tool) => {
+        await chmodPromise(filesystem.resolve(BIN_PATH, tool), 0o751)
+        await filesystem.copyAsync(
+          filesystem.resolve(BIN_PATH, tool),
+          filesystem.resolve(DEBUG_BIN_PATH, tool)
+        )
+      })
+    )
+
+    spinner.info('Reinstalling simulator')
+    filesystem.dir(
+      filesystem.resolve(
+        BUILD_DIR,
+        '..',
+        '..',
+        'tmp',
+        'lin',
+        'debug',
+        'simulator'
+      )
+    )
+    await system.exec(
+      `mcconfig -m -p x-lin ${filesystem.resolve(
+        INSTALL_PATH,
+        'tools',
+        'xsbug',
+        'manifest.json'
+      )}`,
+      { process }
+    )
+    await system.exec(
+      `mcconfig -m -p x-lin ${filesystem.resolve(
+        INSTALL_PATH,
+        'tools',
+        'mcsim',
+        'manifest.json'
+      )}`,
+      { process }
+    )
+    await execWithSudo('make install', {
+      cwd: BUILD_DIR,
+      stdout: process.stdout,
+    })
+    spinner.succeed(
+      'Moddable SDK successfully updated! Start the xsbug.app and run the "helloworld example": xs-dev run --example helloworld'
+    )
   }
 
-  const spinner = print.spin()
-  spinner.start('Updating Moddable SDK!')
+  if (targetBranch === 'public') {
+    const currentRev: string = await system.exec('git rev-parse public', {
+      cwd: process.env.MODDABLE,
+    })
+    const remoteRev: string = await system.exec(
+      'git ls-remote origin refs/heads/public',
+      { cwd: process.env.MODDABLE }
+    )
 
-  spinner.start('Stashing any unsaved changes before committing')
-  await system.exec('git stash', { cwd: process.env.MODDABLE })
-  await system.exec('git pull origin public', { cwd: process.env.MODDABLE })
+    if (remoteRev.split('\t').shift() === currentRev.trim()) {
+      print.success('Moddable SDK already up to date!')
+      process.exit(0)
+    }
 
-  await system.exec('rm -rf build/{tmp,bin}', { cwd: process.env.MODDABLE })
-  spinner.succeed()
+    const spinner = print.spin()
+    spinner.start('Updating Moddable SDK!')
 
-  spinner.start('Rebuilding platform tools')
-  await system.exec('make', {
-    cwd: BUILD_DIR,
-    stdout: process.stdout,
-  })
-  spinner.succeed()
+    spinner.start('Stashing any unsaved changes before committing')
+    await system.exec('git stash', { cwd: process.env.MODDABLE })
+    await system.exec('git pull origin public', { cwd: process.env.MODDABLE })
 
-  spinner.start('Reinstalling simulator')
-  await system.exec('make install', {
-    cwd: BUILD_DIR,
-    stdout: process.stdout,
-    stdin: process.stdin,
-  })
-  spinner.succeed()
+    await system.exec('rm -rf build/{tmp,bin}', { cwd: process.env.MODDABLE })
+    spinner.succeed()
 
-  print.success(
-    'Moddable SDK successfully updated! Start the xsbug.app and run the "helloworld example": xs-dev run --example helloworld'
-  )
+    spinner.start('Rebuilding platform tools')
+    await system.exec('make', {
+      cwd: BUILD_DIR,
+      stdout: process.stdout,
+    })
+    spinner.succeed()
+
+    spinner.start('Reinstalling simulator')
+    await execWithSudo('make install', {
+      cwd: BUILD_DIR,
+      stdout: process.stdout,
+    })
+    spinner.succeed()
+
+    print.success(
+      'Moddable SDK successfully updated! Start the xsbug.app and run the "helloworld example": xs-dev run --example helloworld'
+    )
+  }
 }

--- a/src/toolbox/update/mac.ts
+++ b/src/toolbox/update/mac.ts
@@ -1,7 +1,18 @@
+import os from 'os'
+import { promisify } from 'util'
+import { chmod } from 'fs'
 import { print, system, filesystem } from 'gluegun'
-import { moddableExists } from '../setup/moddable'
+import { INSTALL_PATH, MODDABLE_REPO } from '../setup/constants'
+import {
+  fetchLatestRelease,
+  moddableExists,
+  downloadReleaseTools,
+} from '../setup/moddable'
+import { SetupArgs } from '../setup/types'
 
-export default async function (): Promise<void> {
+const chmodPromise = promisify(chmod)
+
+export default async function ({ targetBranch }: SetupArgs): Promise<void> {
   print.info('Checking for SDK changes')
 
   // 0. ensure Moddable exists
@@ -12,48 +23,132 @@ export default async function (): Promise<void> {
     process.exit(1)
   }
 
-  const currentRev: string = await system.exec('git rev-parse public', {
-    cwd: process.env.MODDABLE,
-  })
-  const remoteRev: string = await system.exec(
-    'git ls-remote origin refs/heads/public',
-    { cwd: process.env.MODDABLE }
-  )
+  if (targetBranch === 'latest-release') {
+    // get tag for current repo
+    const currentTag: string = await system.exec('git tag', {
+      cwd: process.env.MODDABLE,
+    })
+    // get latest release tag
+    const latestRelease = await fetchLatestRelease()
 
-  if (remoteRev.split('\t').shift() === currentRev.trim()) {
-    print.success('Moddable SDK already up to date!')
-    process.exit(0)
+    if (currentTag.trim() === latestRelease.tag_name) {
+      print.success('Moddable SDK already up to date!')
+      process.exit(0)
+    }
+
+    const spinner = print.spin()
+    spinner.start('Updating Moddable SDK!')
+
+    const BIN_PATH = filesystem.resolve(
+      INSTALL_PATH,
+      'build',
+      'bin',
+      'mac',
+      'release'
+    )
+    const DEBUG_BIN_PATH = filesystem.resolve(
+      INSTALL_PATH,
+      'build',
+      'bin',
+      'mac',
+      'debug'
+    )
+
+    filesystem.remove(process.env.MODDABLE)
+    await system.spawn(
+      `git clone ${MODDABLE_REPO} ${INSTALL_PATH} --depth 1 --branch ${latestRelease.tag_name} --single-branch`
+    )
+
+    filesystem.dir(BIN_PATH)
+    filesystem.dir(DEBUG_BIN_PATH)
+
+    const isArm = os.arch() === 'arm64'
+    const assetName = isArm
+      ? 'moddable-tools-mac64arm.zip'
+      : 'moddable-tools-mac64.zip'
+
+    spinner.info('Downloading release tools')
+    await downloadReleaseTools({
+      writePath: BIN_PATH,
+      assetName,
+      release: latestRelease,
+    })
+
+    spinner.info('Updating tool permissions')
+    const tools = filesystem.list(BIN_PATH) ?? []
+    await Promise.all(
+      tools.map(async (tool) => {
+        if (tool.endsWith('.app')) {
+          const mainPath = filesystem.resolve(
+            BIN_PATH,
+            tool,
+            'Contents',
+            'MacOS',
+            'main'
+          )
+          await chmodPromise(mainPath, 0o751)
+        } else {
+          await chmodPromise(filesystem.resolve(BIN_PATH, tool), 0o751)
+        }
+        await filesystem.copyAsync(
+          filesystem.resolve(BIN_PATH, tool),
+          filesystem.resolve(DEBUG_BIN_PATH, tool)
+        )
+      })
+    )
+    spinner.succeed(
+      'Moddable SDK successfully updated! Start the xsbug.app and run the "helloworld example": xs-dev run --example helloworld'
+    )
   }
 
-  const spinner = print.spin()
-  spinner.start('Updating Moddable SDK!')
+  if (targetBranch === 'public') {
+    const currentRev: string = await system.exec('git rev-parse public', {
+      cwd: process.env.MODDABLE,
+    })
+    const remoteRev: string = await system.exec(
+      'git ls-remote origin refs/heads/public',
+      { cwd: process.env.MODDABLE }
+    )
 
-  spinner.start('Stashing any unsaved changes before committing')
-  await system.exec('git stash', { cwd: process.env.MODDABLE })
-  await system.exec('git pull origin public', { cwd: process.env.MODDABLE })
+    if (remoteRev.split('\t').shift() === currentRev.trim()) {
+      print.success('Moddable SDK already up to date!')
+      process.exit(0)
+    }
 
-  const BUILD_DIR = filesystem.resolve(
-    process.env.MODDABLE ?? '',
-    'build',
-    'bin'
-  )
-  const TMP_DIR = filesystem.resolve(process.env.MODDABLE ?? '', 'build', 'tmp')
-  filesystem.remove(BUILD_DIR)
-  filesystem.remove(TMP_DIR)
-  spinner.succeed()
+    const spinner = print.spin()
+    spinner.start('Updating Moddable SDK!')
 
-  spinner.start('Rebuilding platform tools')
-  await system.exec('make', {
-    cwd: filesystem.resolve(
-      String(process.env.MODDABLE),
+    spinner.start('Stashing any unsaved changes before committing')
+    await system.exec('git stash', { cwd: process.env.MODDABLE })
+    await system.exec('git pull origin public', { cwd: process.env.MODDABLE })
+
+    const BUILD_DIR = filesystem.resolve(
+      process.env.MODDABLE ?? '',
       'build',
-      'makefiles',
-      'mac'
-    ),
-    stdout: process.stdout,
-  })
+      'bin'
+    )
+    const TMP_DIR = filesystem.resolve(
+      process.env.MODDABLE ?? '',
+      'build',
+      'tmp'
+    )
+    filesystem.remove(BUILD_DIR)
+    filesystem.remove(TMP_DIR)
+    spinner.succeed()
 
-  spinner.succeed(
-    'Moddable SDK successfully updated! Start the xsbug.app and run the "helloworld example": xs-dev run --example helloworld'
-  )
+    spinner.start('Rebuilding platform tools')
+    // install release assets or build
+    await system.exec('make', {
+      cwd: filesystem.resolve(
+        String(process.env.MODDABLE),
+        'build',
+        'makefiles',
+        'mac'
+      ),
+      stdout: process.stdout,
+    })
+    spinner.succeed(
+      'Moddable SDK successfully updated! Start the xsbug.app and run the "helloworld example": xs-dev run --example helloworld'
+    )
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,5 +16,8 @@ export interface XSDevToolbox extends GluegunToolbox {
     Device,
     (() => Promise<void>) | ((args: SetupArgs) => Promise<void>)
   >
-  update: Record<Device, () => Promise<void>>
+  update: Record<
+    Device,
+    (() => Promise<void>) | ((args: SetupArgs) => Promise<void>)
+  >
 }


### PR DESCRIPTION
Follow up to #57 for the `update` command. There is probably some room for refactoring the common functionality around using the latest release assets but that can be explored later as the Windows platform support comes online. 