### PR TITLE
feat(build): add initial command w/ deploy flag

### DIFF
--- a/.changeset/slimy-crabs-rush.md
+++ b/.changeset/slimy-crabs-rush.md
@@ -1,0 +1,5 @@
+---
+'xs-dev': minor
+---
+
+Add build command for preparing production release output and deployment

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ npm-debug.log
 coverage
 .nyc_output
 dist
-build
+build/
 .vscode
+!src/toolbox/build/

--- a/docs/src/pages/en/features/run.md
+++ b/docs/src/pages/en/features/run.md
@@ -1,10 +1,10 @@
 ---
-title: Run
+title: Build and Run
 description: Build and run Moddable projects or examples
 layout: ../../../layouts/MainLayout.astro
 ---
 
-# Run Moddable projects
+## Running Projects
 
 Within a project directory, the `run` command will invoke [`mcconfig`](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/tools/tools.md#mcconfig) to generate the `make` file based on the `manifest.json` followed by building and running the project in the current environment simulator:
 
@@ -61,3 +61,30 @@ xs-dev run --port /dev/cu.usbserial-0001 --device esp8266
 ```
 
 _This value can be discovered using the [`scan`](./scan) command._
+
+
+## Building projects for release
+
+Within a project directory, the `build` command takes the same flags as the `run` command to invoke [`mcconfig`](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/tools/tools.md#mcconfig) to generate the `make` file based on the `manifest.json` followed by only building the project for [the target device](#select-a-device-target):
+
+```
+xs-dev build --device esp32
+```
+
+The build `--mode` can be set to `production` for the optimized release code or `development` for the debug-enabled release code. This will default to the `NODE_ENV` environment variable or `development` if that variable is not set.
+
+```
+xs-dev build --mode production --device esp32
+```
+
+The output directory can also be set using the `--output` flag, overriding the default path of `$MODDABLE/build`, where `$MODDABLE` is the location of the Moddable tooling repo on your local filesystem.
+
+```
+xs-dev build --output ./dist --device esp32
+```
+
+If you want to immediately deploy the release build, use the `--deploy` flag:
+
+```
+xs-dev build --deploy --device esp32
+```

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,0 +1,52 @@
+import type { GluegunCommand } from 'gluegun'
+import { type as platformType } from 'os'
+import type { Device, XSDevToolbox } from '../types'
+import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
+
+type Mode = 'development' | 'production'
+
+interface BuildOptions {
+  device?: Device
+  port?: string
+  example?: string
+  listExamples?: boolean
+  listDevices?: boolean
+  mode?: Mode
+  output?: string
+}
+
+const command: GluegunCommand<XSDevToolbox> = {
+  name: 'build',
+  description: 'Build project for release to target device',
+  run: async ({ parameters, filesystem, build }) => {
+    const currentPlatform: Device = platformType().toLowerCase() as Device
+    const {
+      device = currentPlatform,
+      port,
+      example,
+      listExamples = false,
+      listDevices = false,
+      mode = (process.env.NODE_ENV as Mode) ?? 'development',
+      output = '',
+    }: BuildOptions = parameters.options
+    const targetPlatform: string = DEVICE_ALIAS[device] ?? device
+    const projectPath = filesystem.resolve(parameters.first ?? '.')
+
+    await build({
+      port,
+      listExamples,
+      listDevices,
+      example,
+      targetPlatform,
+      projectPath,
+      mode,
+      deploy: false,
+      outputDir:
+        output !== ''
+          ? filesystem.resolve(output)
+          : filesystem.resolve(String(process.env.MODDABLE), 'build'),
+    })
+  },
+}
+
+export default command

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -13,6 +13,7 @@ interface BuildOptions {
   listDevices?: boolean
   mode?: Mode
   output?: string
+  deploy?: boolean
 }
 
 const command: GluegunCommand<XSDevToolbox> = {
@@ -28,6 +29,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       listDevices = false,
       mode = (process.env.NODE_ENV as Mode) ?? 'development',
       output = '',
+      deploy = false,
     }: BuildOptions = parameters.options
     const targetPlatform: string = DEVICE_ALIAS[device] ?? device
     const projectPath = filesystem.resolve(parameters.first ?? '.')
@@ -40,7 +42,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       targetPlatform,
       projectPath,
       mode,
-      deploy: false,
+      deployStatus: deploy ? 'push' : 'none',
       outputDir:
         output !== ''
           ? filesystem.resolve(output)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -40,7 +40,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       targetPlatform,
       projectPath,
       mode,
-      deploy: true,
+      deployStatus: 'run',
       outputDir: output,
     })
   },

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,12 +3,16 @@ import { type as platformType } from 'os'
 import type { Device, XSDevToolbox } from '../types'
 import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 
+type Mode = 'development' | 'production'
+
 interface RunOptions {
   device?: Device
   port?: string
   example?: string
   listExamples?: boolean
   listDevices?: boolean
+  mode?: Mode
+  output?: string
 }
 
 const command: GluegunCommand<XSDevToolbox> = {
@@ -22,6 +26,8 @@ const command: GluegunCommand<XSDevToolbox> = {
       example,
       listExamples = false,
       listDevices = false,
+      mode = (process.env.NODE_ENV as Mode) ?? 'development',
+      output = filesystem.resolve(String(process.env.MODDABLE), 'build'),
     }: RunOptions = parameters.options
     const targetPlatform: string = DEVICE_ALIAS[device] ?? device
     const projectPath = filesystem.resolve(parameters.first ?? '.')
@@ -33,6 +39,9 @@ const command: GluegunCommand<XSDevToolbox> = {
       example,
       targetPlatform,
       projectPath,
+      mode,
+      deploy: true,
+      outputDir: output,
     })
   },
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,9 +1,6 @@
 import type { GluegunCommand } from 'gluegun'
 import { type as platformType } from 'os'
-import handler from 'serve-handler'
-import { createServer } from 'http'
 import type { Device, XSDevToolbox } from '../types'
-import { collectChoicesFromTree } from '../toolbox/prompt/choices'
 import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 
 interface RunOptions {
@@ -17,7 +14,7 @@ interface RunOptions {
 const command: GluegunCommand<XSDevToolbox> = {
   name: 'run',
   description: 'Build and launch project on target device or simulator',
-  run: async ({ parameters, print, system, filesystem, prompt }) => {
+  run: async ({ parameters, filesystem, build }) => {
     const currentPlatform: Device = platformType().toLowerCase() as Device
     const {
       device = currentPlatform,
@@ -26,155 +23,17 @@ const command: GluegunCommand<XSDevToolbox> = {
       listExamples = false,
       listDevices = false,
     }: RunOptions = parameters.options
-    let targetPlatform: string = DEVICE_ALIAS[device] ?? device
-    let projectPath = filesystem.resolve(parameters.first ?? '.')
+    const targetPlatform: string = DEVICE_ALIAS[device] ?? device
+    const projectPath = filesystem.resolve(parameters.first ?? '.')
 
-    if (listDevices) {
-      const choices = [
-        'esp',
-        'esp/moddable_zero',
-        'esp/moddable_one',
-        'esp/moddable_three',
-        'esp/nodemcu',
-        'esp32',
-        'esp32/moddable_two',
-        'esp32/nodemcu',
-        'esp32/m5stack',
-        'esp32/m5stack_core2',
-        'esp32/m5stick_fire',
-        'esp32/m5atom_echo',
-        'esp32/m5atom_lite',
-        'esp32/m5atom_matrix',
-        'esp32/m5paper',
-        'esp32/m5core_ink',
-        'esp32/heltec_wifi_kit_32',
-        'esp32/esp32_thing',
-        'esp32/esp32_thing_plus',
-        'esp32/wrover_kit',
-        'esp32/kaluga',
-        'esp32/saola_wroom',
-        'esp32/saola_wrover',
-        'wasm',
-        'pico',
-        'pico/ili9341',
-        'pico/pico_display',
-        'pico/pico_display_2',
-        'simulator/moddable_one',
-        'simulator/moddable_two',
-        'simulator/moddable_three',
-        'simulator/m5stickc',
-        'simulator/m5paper',
-        'simulator/nodemcu',
-        'simulator/pico_display',
-        'simulator/pico_display_2',
-      ]
-      const { device: selectedDevice } = await prompt.ask([
-        {
-          type: 'autocomplete',
-          name: 'device',
-          message: 'Here are the available target devices:',
-          choices,
-        },
-      ])
-
-      if (selectedDevice !== '' && selectedDevice !== undefined) {
-        targetPlatform = selectedDevice
-      } else {
-        print.warning('Please select a target device to run')
-        process.exit(0)
-      }
-    }
-
-    if (listExamples) {
-      const exampleProjectPath = filesystem.resolve(
-        String(process.env.MODDABLE),
-        'examples'
-      )
-      const examples = filesystem.inspectTree(exampleProjectPath)?.children
-      const choices =
-        examples !== undefined
-          ? examples.map((example) => collectChoicesFromTree(example)).flat()
-          : []
-      const { example: selectedExample } = await prompt.ask([
-        {
-          type: 'autocomplete',
-          name: 'example',
-          message: 'Here are the available examples:',
-          choices,
-        },
-      ])
-
-      if (selectedExample !== '' && selectedExample !== undefined) {
-        print.info(
-          `Running the example: xs-dev run --example ${selectedExample}`
-        )
-        projectPath = filesystem.resolve(exampleProjectPath, selectedExample)
-      } else {
-        print.warning('Please select an example to run.')
-        process.exit(0)
-      }
-    }
-
-    if (example !== undefined) {
-      const exampleProjectPath = filesystem.resolve(
-        String(process.env.MODDABLE),
-        'examples',
-        example
-      )
-      if (filesystem.exists(exampleProjectPath) === false) {
-        print.error('Example project does not exist.')
-        print.info(`Lookup the available examples: xs-dev run --list-examples`)
-        process.exit(1)
-      }
-      if (
-        filesystem.exists(
-          filesystem.resolve(exampleProjectPath, 'manifest.json')
-        ) === false
-      ) {
-        print.error('Example project must contain a manifest.json.')
-        print.info(`Lookup the available examples: xs-dev run --list-examples`)
-        process.exit(1)
-      }
-      projectPath = exampleProjectPath
-    }
-
-    if (port !== undefined) {
-      process.env.UPLOAD_PORT = port
-    }
-
-    const spinner = print.spin()
-
-    spinner.start(
-      `Building and running project ${projectPath} on ${targetPlatform}`
-    )
-
-    await system.exec(`mcconfig -d -m -p ${targetPlatform}`, {
-      cwd: projectPath,
-      process,
+    await build({
+      port,
+      listExamples,
+      listDevices,
+      example,
+      targetPlatform,
+      projectPath,
     })
-
-    spinner.stop()
-
-    if (targetPlatform === 'wasm') {
-      const buildName = String(projectPath.split('/').pop())
-      const debugPath = filesystem.resolve(
-        String(process.env.MODDABLE),
-        'build',
-        'bin',
-        'wasm',
-        'debug',
-        buildName
-      )
-      createServer((req, res) => {
-        void handler(req, res, { public: debugPath })
-      }).listen(8080, () => {
-        print.info(
-          'Started server on port 8080, go to http://localhost:8080 in your browser to view the simulator'
-        )
-      })
-    } else {
-      process.exit(0)
-    }
   },
 }
 

--- a/src/extensions/build-extension.ts
+++ b/src/extensions/build-extension.ts
@@ -1,0 +1,6 @@
+import { XSDevToolbox } from '../types'
+import { build } from '../toolbox/build/index'
+
+export default async (toolbox: XSDevToolbox): Promise<void> => {
+  toolbox.build = build
+}

--- a/src/toolbox/build/index.ts
+++ b/src/toolbox/build/index.ts
@@ -140,7 +140,9 @@ export async function build({
   const spinner = print.spin()
 
   spinner.start(
-    `Building and running project ${projectPath} on ${targetPlatform}`
+    `Building${
+      deploy ? ' and running project' : ''
+    } ${projectPath} on ${targetPlatform}`
   )
 
   const configArgs = [

--- a/src/toolbox/build/index.ts
+++ b/src/toolbox/build/index.ts
@@ -10,6 +10,9 @@ export interface BuildArgs {
   listDevices: boolean
   projectPath: string
   targetPlatform: string
+  mode: 'development' | 'production'
+  deploy: boolean
+  outputDir: string
 }
 
 export async function build({
@@ -19,6 +22,9 @@ export async function build({
   listExamples,
   projectPath,
   targetPlatform,
+  mode,
+  deploy,
+  outputDir,
 }: BuildArgs): Promise<void> {
   if (listDevices) {
     const choices = [
@@ -137,7 +143,16 @@ export async function build({
     `Building and running project ${projectPath} on ${targetPlatform}`
   )
 
-  await system.exec(`mcconfig -d -m -p ${targetPlatform}`, {
+  const configArgs = [
+    '-m',
+    `-p ${targetPlatform}`,
+    `-t ${deploy ? 'all' : 'build'}`,
+    `-o ${outputDir}`,
+  ]
+  if (mode === 'development') configArgs.push('-d')
+  if (mode === 'production') configArgs.push('-i')
+
+  await system.exec(`mcconfig ${configArgs.join(' ')}`, {
     cwd: projectPath,
     process,
   })

--- a/src/toolbox/build/index.ts
+++ b/src/toolbox/build/index.ts
@@ -1,0 +1,167 @@
+import handler from 'serve-handler'
+import { createServer } from 'http'
+import { filesystem, print, prompt, system } from 'gluegun'
+import { collectChoicesFromTree } from '../prompt/choices'
+
+export interface BuildArgs {
+  port?: string
+  example?: string
+  listExamples: boolean
+  listDevices: boolean
+  projectPath: string
+  targetPlatform: string
+}
+
+export async function build({
+  listDevices,
+  port,
+  example,
+  listExamples,
+  projectPath,
+  targetPlatform,
+}: BuildArgs): Promise<void> {
+  if (listDevices) {
+    const choices = [
+      'esp',
+      'esp/moddable_zero',
+      'esp/moddable_one',
+      'esp/moddable_three',
+      'esp/nodemcu',
+      'esp32',
+      'esp32/moddable_two',
+      'esp32/nodemcu',
+      'esp32/m5stack',
+      'esp32/m5stack_core2',
+      'esp32/m5stick_fire',
+      'esp32/m5atom_echo',
+      'esp32/m5atom_lite',
+      'esp32/m5atom_matrix',
+      'esp32/m5paper',
+      'esp32/m5core_ink',
+      'esp32/heltec_wifi_kit_32',
+      'esp32/esp32_thing',
+      'esp32/esp32_thing_plus',
+      'esp32/wrover_kit',
+      'esp32/kaluga',
+      'esp32/saola_wroom',
+      'esp32/saola_wrover',
+      'wasm',
+      'pico',
+      'pico/ili9341',
+      'pico/pico_display',
+      'pico/pico_display_2',
+      'simulator/moddable_one',
+      'simulator/moddable_two',
+      'simulator/moddable_three',
+      'simulator/m5stickc',
+      'simulator/m5paper',
+      'simulator/nodemcu',
+      'simulator/pico_display',
+      'simulator/pico_display_2',
+    ]
+    const { device: selectedDevice } = await prompt.ask([
+      {
+        type: 'autocomplete',
+        name: 'device',
+        message: 'Here are the available target devices:',
+        choices,
+      },
+    ])
+
+    if (selectedDevice !== '' && selectedDevice !== undefined) {
+      targetPlatform = selectedDevice
+    } else {
+      print.warning('Please select a target device to run')
+      process.exit(0)
+    }
+  }
+
+  if (listExamples) {
+    const exampleProjectPath = filesystem.resolve(
+      String(process.env.MODDABLE),
+      'examples'
+    )
+    const examples = filesystem.inspectTree(exampleProjectPath)?.children
+    const choices =
+      examples !== undefined
+        ? examples.map((example) => collectChoicesFromTree(example)).flat()
+        : []
+    const { example: selectedExample } = await prompt.ask([
+      {
+        type: 'autocomplete',
+        name: 'example',
+        message: 'Here are the available examples:',
+        choices,
+      },
+    ])
+
+    if (selectedExample !== '' && selectedExample !== undefined) {
+      print.info(`Running the example: xs-dev run --example ${selectedExample}`)
+      projectPath = filesystem.resolve(exampleProjectPath, selectedExample)
+    } else {
+      print.warning('Please select an example to run.')
+      process.exit(0)
+    }
+  }
+
+  if (example !== undefined) {
+    const exampleProjectPath = filesystem.resolve(
+      String(process.env.MODDABLE),
+      'examples',
+      example
+    )
+    if (filesystem.exists(exampleProjectPath) === false) {
+      print.error('Example project does not exist.')
+      print.info(`Lookup the available examples: xs-dev run --list-examples`)
+      process.exit(1)
+    }
+    if (
+      filesystem.exists(
+        filesystem.resolve(exampleProjectPath, 'manifest.json')
+      ) === false
+    ) {
+      print.error('Example project must contain a manifest.json.')
+      print.info(`Lookup the available examples: xs-dev run --list-examples`)
+      process.exit(1)
+    }
+    projectPath = exampleProjectPath
+  }
+
+  if (port !== undefined) {
+    process.env.UPLOAD_PORT = port
+  }
+
+  const spinner = print.spin()
+
+  spinner.start(
+    `Building and running project ${projectPath} on ${targetPlatform}`
+  )
+
+  await system.exec(`mcconfig -d -m -p ${targetPlatform}`, {
+    cwd: projectPath,
+    process,
+  })
+
+  spinner.stop()
+
+  if (targetPlatform === 'wasm') {
+    const buildName = String(projectPath.split('/').pop())
+    const debugPath = filesystem.resolve(
+      String(process.env.MODDABLE),
+      'build',
+      'bin',
+      'wasm',
+      'debug',
+      buildName
+    )
+    createServer((req, res) => {
+      void handler(req, res, { public: debugPath })
+    }).listen(8080, () => {
+      print.info(
+        'Started server on port 8080, go to http://localhost:8080 in your browser to view the simulator'
+      )
+    })
+  } else {
+    process.exit(0)
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { GluegunToolbox } from 'gluegun'
-import { SetupArgs } from './toolbox/setup/types'
+import type { SetupArgs } from './toolbox/setup/types'
+import type { BuildArgs } from './toolbox/build/index'
 
 export type Device =
   | 'darwin'
@@ -20,4 +21,5 @@ export interface XSDevToolbox extends GluegunToolbox {
     Device,
     (() => Promise<void>) | ((args: SetupArgs) => Promise<void>)
   >
+  build: (args: BuildArgs) => Promise<void>
 }


### PR DESCRIPTION
This PR includes a refactor of the build and run logic for Moddable projects in the `run` command for reuse in a separate `build` command to help with preparing for a production environment release. 

Updated docs page:
![Screenshot 2022-08-25 at 10-13-21 Build and Run 🚀 xs-dev Documentation](https://user-images.githubusercontent.com/3051193/186691669-007fb697-c372-4fe4-a0fb-0801500df7a9.png)

