### PR TITLE
Adds asyncMain option to init command

### DIFF
--- a/docs/src/pages/en/features/init.md
+++ b/docs/src/pages/en/features/init.md
@@ -28,6 +28,14 @@ The `--io` flag sets up the project to use the [TC53 IO manifest](https://github
 xs-dev init my-io-project --io
 ```
 
+## asyncMain
+
+The `--asyncMain` flag will enable top level await in your project's entry file. In XS, TLA is only be available in imported modules by default.
+
+```
+xs-dev init my-io-project --asyncMain
+```
+
 ## Moddable example
 
 For the `--example` flag, it can be used as a boolean to select a project from the list of available [Moddable examples](https://github.com/Moddable-OpenSource/moddable/tree/public/examples):

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,7 +5,8 @@ interface InitOptions {
   typescript?: boolean
   io?: boolean
   example?: string | boolean
-  overwrite?: boolean
+  overwrite?: boolean,
+  asyncMain?: boolean
 }
 
 const command: GluegunCommand = {
@@ -27,6 +28,7 @@ const command: GluegunCommand = {
       io = false,
       example = false,
       overwrite = false,
+      asyncMain = false,
     }: InitOptions = parameters.options
 
     if (name !== undefined) {
@@ -89,10 +91,14 @@ const command: GluegunCommand = {
           .filter(Boolean)
           .join(',\n\t')
 
+        const defines: String = asyncMain
+          ? ',\n  defines: {\n    async_main: 1\n  }'
+          : ''
+
         await generate({
           template: 'manifest.json.ejs',
           target: `${name}/manifest.json`,
-          props: { includes },
+          props: { includes, defines },
         })
 
         await generate({

--- a/src/templates/manifest.json.ejs
+++ b/src/templates/manifest.json.ejs
@@ -4,5 +4,5 @@
   ],
   "modules": {
     "*": "./main"
-  }
+  }<%- props.defines %>
 }


### PR DESCRIPTION
Addresses #65

I'm not proud of the approach I took to keep the JSON "pretty". I didn't want an empty defines object being output when asyncMain was not invoked, but if another defines option is added, this will become awkward.

Creating a JSON object and writing the stringified object to the filesystem might be more future proof than using strings and an ejs template.

Finally, the property name for XS' manifest.json is `async_main`, but ES Lint complains about that style so I've used `asyncMain` for the param. It bothers me that they don't match, but a contributor changing `.eslint.js` is kinda like having a houseguest rearrange furniture. I don't want to be that guy.