### PR TITLE
fix: ensure homebrew is available before running install commands

### DIFF
--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -95,9 +95,6 @@ export default async function(): Promise<void> {
   } else {
     spinner.info('Sourcing esp-idf environment')
     await upsert(EXPORTS_FILE_PATH, `source $IDF_PATH/export.sh 1> /dev/null`)
-    await system.exec('source $IDF_PATH/export.sh', {
-      shell: process.env.SHELL,
-    })
   }
 
   spinner.succeed(`

--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -39,7 +39,7 @@ export default async function(): Promise<void> {
   if (filesystem.exists(IDF_PATH) === false) {
     spinner.start('Cloning esp-idf repo')
     await system.spawn(
-      `git clone -b ${ESP_BRANCH} --recursive ${ESP_IDF_REPO} ${IDF_PATH}`
+      `git clone --depth 1 --single-branch -b ${ESP_BRANCH} --recursive ${ESP_IDF_REPO} ${IDF_PATH}`
     )
     spinner.succeed()
   }

--- a/src/toolbox/setup/esp32/mac.ts
+++ b/src/toolbox/setup/esp32/mac.ts
@@ -35,7 +35,7 @@ export async function installDeps(
     } else {
       try {
         filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
-      } finally {
+      } catch (error) {
         print.info('Using existing python3 for python')
       }
     }

--- a/src/toolbox/setup/esp32/mac.ts
+++ b/src/toolbox/setup/esp32/mac.ts
@@ -33,7 +33,11 @@ export async function installDeps(
         }
       }
     } else {
-      filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
+      try {
+        filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
+      } finally {
+        print.info('Using existing python3 for python')
+      }
     }
   }
 

--- a/src/toolbox/setup/esp32/mac.ts
+++ b/src/toolbox/setup/esp32/mac.ts
@@ -1,4 +1,4 @@
-import { system, semver, print, filesystem } from 'gluegun'
+import { system, semver, print } from 'gluegun'
 import type { GluegunPrint } from 'gluegun'
 import { ensureHomebrew } from '../homebrew'
 
@@ -8,7 +8,14 @@ export async function installDeps(
 ): Promise<void> {
   spinner.stop()
 
-  await ensureHomebrew()
+  try {
+    await ensureHomebrew()
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      print.info(`${error.message} python 3, cmake, ninja, dfu-util`)
+      process.exit(1);
+    }
+  }
 
   if (
     system.which('python') === null ||
@@ -31,12 +38,6 @@ export async function installDeps(
           print.error('Apple Command Line Tools must be installed in order to install python from Homebrew. Please run `xcode-select --install` before trying again.')
           process.exit(1)
         }
-      }
-    } else {
-      try {
-        filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
-      } catch (error) {
-        print.info('Using existing python3 for python')
       }
     }
   }

--- a/src/toolbox/setup/esp32/mac.ts
+++ b/src/toolbox/setup/esp32/mac.ts
@@ -1,15 +1,14 @@
-import { system, semver, print } from 'gluegun'
+import { system, semver } from 'gluegun'
 import type { GluegunPrint } from 'gluegun'
+import { ensureHomebrew } from '../homebrew'
 
 // brew install python3, cmake, ninja, dfu-util
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
-  if (system.which('brew') === null) {
-    print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
-If you don't want to use Homebrew, please install python, cmake, ninja, and dfu-util manually before trying this command again.`)
-    process.exit(1);
-  }
+  spinner.stop()
+
+  await ensureHomebrew()
 
   if (
     system.which('python') === null ||
@@ -22,30 +21,30 @@ If you don't want to use Homebrew, please install python, cmake, ninja, and dfu-
       '>= 3.x.x'
     )
   ) {
-    await system.exec('brew install python')
+    await system.exec('brew install python', { shell: process.env.SHELL })
   }
 
   if (system.which('cmake') === null) {
-    await system.exec('brew install cmake')
+    await system.exec('brew install cmake', { shell: process.env.SHELL })
   }
 
   if (system.which('ninja') === null) {
-    await system.exec('brew install ninja')
+    await system.exec('brew install ninja', { shell: process.env.SHELL })
   }
 
   if (system.which('dfu-util') === null) {
-    await system.exec('brew install dfu-util')
+    await system.exec('brew install dfu-util', { shell: process.env.SHELL })
   }
 
   // 4. install pip, if needed
   if (system.which('pip3') === null) {
     spinner.start('Installing pip3')
-    await system.exec('python3 -m ensurepip --user')
+    await system.exec('python3 -m ensurepip --user', { shell: process.env.SHELL })
     spinner.succeed()
   }
 
   // 5. pip install pyserial, if needed
   spinner.start('Installing pyserial through pip3')
-  await system.exec('python3 -m pip install pyserial')
+  await system.exec('python3 -m pip install pyserial', { shell: process.env.SHELL })
   spinner.succeed()
 }

--- a/src/toolbox/setup/esp32/mac.ts
+++ b/src/toolbox/setup/esp32/mac.ts
@@ -1,10 +1,16 @@
-import { system, semver } from 'gluegun'
+import { system, semver, print } from 'gluegun'
 import type { GluegunPrint } from 'gluegun'
 
 // brew install python3, cmake, ninja, dfu-util
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
+  if (system.which('brew') === null) {
+    print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
+If you don't want to use Homebrew, please install python, cmake, ninja, and dfu-util manually before trying this command again.`)
+    process.exit(1);
+  }
+
   if (
     system.which('python') === null ||
     // get python verion, check if v3

--- a/src/toolbox/setup/esp8266.ts
+++ b/src/toolbox/setup/esp8266.ts
@@ -89,7 +89,7 @@ export default async function(): Promise<void> {
   if (filesystem.exists(RTOS_PATH) === false) {
     spinner.start('Cloning esp8266 RTOS SDK repo')
     await system.spawn(
-      `git clone -b ${ESP_BRANCH} ${ESP_RTOS_REPO} ${RTOS_PATH}`
+      `git clone --depth 1 --single-branch -b ${ESP_BRANCH} ${ESP_RTOS_REPO} ${RTOS_PATH}`
     )
     spinner.succeed()
   }

--- a/src/toolbox/setup/esp8266/mac.ts
+++ b/src/toolbox/setup/esp8266/mac.ts
@@ -1,11 +1,18 @@
-import { filesystem, print, system } from 'gluegun'
+import { print, system } from 'gluegun'
 import type { GluegunPrint } from 'gluegun'
 import { ensureHomebrew } from '../homebrew'
 
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
-  await ensureHomebrew()
+  try {
+    await ensureHomebrew()
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      print.info(`${error.message} python`)
+      process.exit(1);
+    }
+  }
 
   if (system.which('python') === null) {
     const maybePython3Path = system.which('python3')
@@ -20,12 +27,6 @@ export async function installDeps(
           spinner.fail('Apple Command Line Tools must be installed in order to install python from Homebrew. Please run `xcode-select --install` before trying again.')
           process.exit(1)
         }
-      }
-    } else {
-      try {
-        filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
-      } catch (error) {
-        print.info('Using existing python3 for python')
       }
     }
   }

--- a/src/toolbox/setup/esp8266/mac.ts
+++ b/src/toolbox/setup/esp8266/mac.ts
@@ -1,15 +1,12 @@
-import { print, system } from 'gluegun'
+import { system } from 'gluegun'
 import type { GluegunPrint } from 'gluegun'
+import { ensureHomebrew } from '../homebrew'
 
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
   if (system.which('python') === null) {
-    if (system.which('brew') === null) {
-      print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
-  If you don't want to use Homebrew, please install python manually before trying this command again.`)
-      process.exit(1);
-    }
+    await ensureHomebrew()
 
     spinner.start('Installing python from homebrew')
     try {

--- a/src/toolbox/setup/esp8266/mac.ts
+++ b/src/toolbox/setup/esp8266/mac.ts
@@ -1,10 +1,16 @@
-import { system } from 'gluegun'
+import { print, system } from 'gluegun'
 import type { GluegunPrint } from 'gluegun'
 
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
   if (system.which('python') === null) {
+    if (system.which('brew') === null) {
+      print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
+  If you don't want to use Homebrew, please install python manually before trying this command again.`)
+      process.exit(1);
+    }
+
     spinner.start('Installing python from homebrew')
     try {
       await system.exec('brew install python')

--- a/src/toolbox/setup/esp8266/mac.ts
+++ b/src/toolbox/setup/esp8266/mac.ts
@@ -24,7 +24,7 @@ export async function installDeps(
     } else {
       try {
         filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
-      } finally {
+      } catch (error) {
         print.info('Using existing python3 for python')
       }
     }

--- a/src/toolbox/setup/esp8266/mac.ts
+++ b/src/toolbox/setup/esp8266/mac.ts
@@ -1,32 +1,38 @@
-import { system } from 'gluegun'
+import { filesystem, system } from 'gluegun'
 import type { GluegunPrint } from 'gluegun'
 import { ensureHomebrew } from '../homebrew'
 
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
-  if (system.which('python') === null) {
-    await ensureHomebrew()
+  await ensureHomebrew()
 
-    spinner.start('Installing python from homebrew')
-    try {
-      await system.exec('brew install python')
-      spinner.succeed()
-    } catch (error: unknown) {
-      if (error instanceof Error && error.message.includes('xcode-select')) {
-        spinner.fail('Apple Command Line Tools must be installed in order to install python from Homebrew. Please run `xcode-select --install` before trying again.')
-        process.exit(1)
+  if (system.which('python') === null) {
+    const maybePython3Path = system.which('python3')
+
+    if (typeof maybePython3Path !== 'string') {
+      spinner.start('Installing python from homebrew')
+      try {
+        await system.exec('brew install python', { shell: process.env.SHELL })
+        spinner.succeed()
+      } catch (error: unknown) {
+        if (error instanceof Error && error.message.includes('xcode-select')) {
+          spinner.fail('Apple Command Line Tools must be installed in order to install python from Homebrew. Please run `xcode-select --install` before trying again.')
+          process.exit(1)
+        }
       }
+    } else {
+      filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
     }
   }
 
-  if (system.which('pip') === null) {
+  if (system.which('pip') === null || system.which('pip3') === null) {
     spinner.start('Installing pip through ensurepip')
-    await system.exec('python -m ensurepip')
+    await system.exec('python3 -m ensurepip --user')
     spinner.succeed()
   }
 
   spinner.start('Installing pyserial through pip')
-  await system.exec('python -m pip install pyserial')
+  await system.exec('python3 -m pip install pyserial')
   spinner.succeed()
 }

--- a/src/toolbox/setup/esp8266/mac.ts
+++ b/src/toolbox/setup/esp8266/mac.ts
@@ -1,4 +1,4 @@
-import { filesystem, system } from 'gluegun'
+import { filesystem, print, system } from 'gluegun'
 import type { GluegunPrint } from 'gluegun'
 import { ensureHomebrew } from '../homebrew'
 
@@ -22,7 +22,11 @@ export async function installDeps(
         }
       }
     } else {
-      filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
+      try {
+        filesystem.symlink(maybePython3Path, maybePython3Path.slice(0, -1))
+      } finally {
+        print.info('Using existing python3 for python')
+      }
     }
   }
 

--- a/src/toolbox/setup/fontbm.ts
+++ b/src/toolbox/setup/fontbm.ts
@@ -5,7 +5,7 @@ import { type as platformType } from 'os'
 import { exit } from 'process'
 import { execWithSudo } from '../system/exec'
 
-export default async function (): Promise<void> {
+export default async function(): Promise<void> {
   const spinner = print.spin()
   spinner.start('Beginning setup...')
 
@@ -22,11 +22,17 @@ export default async function (): Promise<void> {
   // 1. install cmake
   if (system.which('cmake') === null) {
     if (OS === 'darwin') {
+      if (system.which('brew') === null) {
+        print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
+  If you don't want to use Homebrew, please install cmake manually before trying this command again.`)
+        process.exit(1);
+      }
+
       spinner.start('Cmake required, installing with Homebrew')
-   	  await system.exec('brew install cmake')
+      await system.exec('brew install cmake')
       spinner.succeed()
-	}
-	if (OS === 'linux') {
+    }
+    if (OS === 'linux') {
       spinner.start('CMake required, installing with apt')
       await execWithSudo(
         'apt-get install --yes build-essential cmake',

--- a/src/toolbox/setup/fontbm.ts
+++ b/src/toolbox/setup/fontbm.ts
@@ -26,7 +26,7 @@ export default async function(): Promise<void> {
       await ensureHomebrew()
 
       spinner.start('Cmake required, installing with Homebrew')
-      await system.exec('brew install cmake')
+      await system.exec('brew install cmake', { shell: process.env.SHELL })
       spinner.succeed()
     }
     if (OS === 'linux') {
@@ -42,8 +42,10 @@ export default async function(): Promise<void> {
   // 2. install freetype
   if (OS === 'darwin') {
     if (system.which('freetype-config') === null) {
+      await ensureHomebrew()
+
       spinner.start('FreeType required, installing with Homebrew')
-      await system.exec('brew install freetype')
+      await system.exec('brew install freetype', { shell: process.env.SHELL })
       spinner.succeed()
     }
   }
@@ -60,7 +62,7 @@ export default async function(): Promise<void> {
   if (filesystem.exists(FONTBM_DIR) === false) {
     spinner.start(`Cloning fontbm repo (tag "${FONTBM_TAG}")`)
     await system.spawn(
-      `git clone ${FONTBM_REPO} --branch ${FONTBM_TAG} ${FONTBM_DIR}`
+      `git clone ${FONTBM_REPO} --depth 1 --single-branch --branch ${FONTBM_TAG} ${FONTBM_DIR}`
     )
     spinner.succeed()
   }

--- a/src/toolbox/setup/fontbm.ts
+++ b/src/toolbox/setup/fontbm.ts
@@ -23,7 +23,14 @@ export default async function(): Promise<void> {
   // 1. install cmake
   if (system.which('cmake') === null) {
     if (OS === 'darwin') {
-      await ensureHomebrew()
+      try {
+        await ensureHomebrew()
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          print.info(`${error.message} cmake`)
+          process.exit(1);
+        }
+      }
 
       spinner.start('Cmake required, installing with Homebrew')
       await system.exec('brew install cmake', { shell: process.env.SHELL })
@@ -42,7 +49,14 @@ export default async function(): Promise<void> {
   // 2. install freetype
   if (OS === 'darwin') {
     if (system.which('freetype-config') === null) {
-      await ensureHomebrew()
+      try {
+        await ensureHomebrew()
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          print.info(`${error.message} freetype-config`)
+          process.exit(1);
+        }
+      }
 
       spinner.start('FreeType required, installing with Homebrew')
       await system.exec('brew install freetype', { shell: process.env.SHELL })

--- a/src/toolbox/setup/fontbm.ts
+++ b/src/toolbox/setup/fontbm.ts
@@ -4,6 +4,7 @@ import upsert from '../patching/upsert'
 import { type as platformType } from 'os'
 import { exit } from 'process'
 import { execWithSudo } from '../system/exec'
+import { ensureHomebrew } from './homebrew'
 
 export default async function(): Promise<void> {
   const spinner = print.spin()
@@ -22,11 +23,7 @@ export default async function(): Promise<void> {
   // 1. install cmake
   if (system.which('cmake') === null) {
     if (OS === 'darwin') {
-      if (system.which('brew') === null) {
-        print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
-  If you don't want to use Homebrew, please install cmake manually before trying this command again.`)
-        process.exit(1);
-      }
+      await ensureHomebrew()
 
       spinner.start('Cmake required, installing with Homebrew')
       await system.exec('brew install cmake')

--- a/src/toolbox/setup/homebrew.ts
+++ b/src/toolbox/setup/homebrew.ts
@@ -14,7 +14,6 @@ export async function ensureHomebrew(): Promise<void> {
     const homebrewEval = `eval "$(${brewPath}/brew shellenv)"`
 
     if (filesystem.exists(brewPath) === 'dir') {
-      print.debug(`Homebrew is on the system but not found in PATH. Running '${homebrewEval}' to attempt to fix PATH for this task`)
       process.env.PATH = `${brewPath}:${String(process.env.PATH)}`
       return;
     }
@@ -31,7 +30,7 @@ export async function ensureHomebrew(): Promise<void> {
         })
         const PROFILE_PATH = getProfilePath()
         await upsert(PROFILE_PATH, homebrewEval)
-        await system.exec(`source ${PROFILE_PATH}`, { shell: process.env.SHELL, stdout: process.stdout })
+        process.env.PATH = `${brewPath}:${String(process.env.PATH)}`
         return;
       } catch (error: unknown) {
         if (error instanceof Error) {

--- a/src/toolbox/setup/homebrew.ts
+++ b/src/toolbox/setup/homebrew.ts
@@ -39,7 +39,6 @@ export async function ensureHomebrew(): Promise<void> {
       }
     }
 
-    print.info(`Visit https://brew.sh/ to learn more about installing Homebrew. If you don't want to use Homebrew, please install python, cmake, ninja, and dfu-util manually before trying this command again.`)
-    process.exit(1);
+    throw new Error(`Visit https://brew.sh/ to learn more about installing Homebrew. If you don't want to use Homebrew, please install the following packages manually before trying this command again: `)
   }
 }

--- a/src/toolbox/setup/homebrew.ts
+++ b/src/toolbox/setup/homebrew.ts
@@ -4,16 +4,17 @@ import upsert from '../patching/upsert'
 import { getProfilePath } from './constants'
 
 function getBrewPath(): string {
-  if (os.arch() === 'arm64') return '/opt/homebrew/bin/brew'
-  return '/usr/local/bin/brew'
+  if (os.arch() === 'arm64') return '/opt/homebrew/bin'
+  return '/usr/local/bin'
 }
 
 export async function ensureHomebrew(): Promise<void> {
   if (system.which('brew') === null) {
     const brewPath = getBrewPath()
-    const homebrewEval = `eval "$(${brewPath} shellenv)"`
+    const homebrewEval = `eval "$(${brewPath}/brew shellenv)"`
 
-    if (filesystem.exists(brewPath) === 'file') {
+    if (filesystem.exists(brewPath) === 'dir') {
+      print.debug(`Homebrew is on the system but not found in PATH. Running '${homebrewEval}' to attempt to fix PATH for this task`)
       await system.exec(homebrewEval, { shell: process.env.SHELL, stdout: process.env.stdout })
       return;
     }

--- a/src/toolbox/setup/homebrew.ts
+++ b/src/toolbox/setup/homebrew.ts
@@ -1,0 +1,32 @@
+import { print, prompt, system } from "gluegun";
+import upsert from "../patching/upsert";
+import { getProfilePath } from "./constants";
+
+export async function ensureHomebrew(): Promise<void> {
+  if (system.which('brew') === null) {
+    const shouldInstallBrew = await prompt.confirm(`The "brew" command is not available. Homebrew is required to install necessary dependencies. Would you like to setup Homebrew automatically?`)
+
+    if (shouldInstallBrew) {
+      try {
+        print.info('Running Homebrew install script...')
+        await system.exec(`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`, {
+          shell: process.env.SHELL,
+          stdout: process.stdout,
+          stdin: process.stdin,
+        })
+        const homebrewEval = `eval "$(/opt/homebrew/bin/brew shellenv)"`
+        const PROFILE_PATH = getProfilePath()
+        await upsert(PROFILE_PATH, homebrewEval)
+        await system.exec(`source ${PROFILE_PATH}`, { shell: process.env.SHELL, stdout: process.stdout })
+        return;
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          print.error(`Unable to install Homebrew: ${error.message}`)
+        }
+      }
+    }
+
+    print.info(`Visit https://brew.sh/ to learn more about installing Homebrew. If you don't want to use Homebrew, please install python, cmake, ninja, and dfu-util manually before trying this command again.`)
+    process.exit(1);
+  }
+}

--- a/src/toolbox/setup/homebrew.ts
+++ b/src/toolbox/setup/homebrew.ts
@@ -15,7 +15,7 @@ export async function ensureHomebrew(): Promise<void> {
 
     if (filesystem.exists(brewPath) === 'dir') {
       print.debug(`Homebrew is on the system but not found in PATH. Running '${homebrewEval}' to attempt to fix PATH for this task`)
-      await system.exec(homebrewEval, { shell: process.env.SHELL, stdout: process.env.stdout })
+      process.env.PATH = `${brewPath}:${String(process.env.PATH)}`
       return;
     }
 

--- a/src/toolbox/setup/pico.ts
+++ b/src/toolbox/setup/pico.ts
@@ -43,7 +43,6 @@ export default async function(): Promise<void> {
       spinner.succeed()
     }
 
-    spinner.start('Tapping ArmMbed formulae and installing arm-embed-gcc')
     await installMacDeps(spinner)
 
     const brewPrefix = await system.run('brew --prefix')
@@ -62,7 +61,7 @@ export default async function(): Promise<void> {
   // 2. Install the pico sdk, examples, and picotool:
   if (filesystem.exists(PICO_SDK_DIR) === false) {
     spinner.start('Cloning pico-sdk repo')
-    await system.exec(`git clone -b master ${PICO_SDK_REPO} ${PICO_SDK_DIR}`, {
+    await system.exec(`git clone --depth 1 --single-branch -b master ${PICO_SDK_REPO} ${PICO_SDK_DIR}`, {
       stdout: process.stdout,
     })
     await system.exec(`git submodule update --init`, {
@@ -75,7 +74,7 @@ export default async function(): Promise<void> {
   if (filesystem.exists(PICO_EXAMPLES_PATH) === false) {
     spinner.start('Cloning pico-exmples repo')
     await system.exec(
-      `git clone -b master ${PICO_EXAMPLES_REPO} ${PICO_EXAMPLES_PATH}`,
+      `git clone --depth 1 --single-branch -b master ${PICO_EXAMPLES_REPO} ${PICO_EXAMPLES_PATH}`,
       { stdout: process.stdout }
     )
     spinner.succeed()
@@ -83,7 +82,7 @@ export default async function(): Promise<void> {
 
   if (filesystem.exists(PICOTOOL_PATH) === false) {
     spinner.start('Cloning picotool repo')
-    await system.exec(`git clone -b master ${PICOTOOL_REPO} ${PICOTOOL_PATH}`, {
+    await system.exec(`git clone --depth 1 --single-branch -b master ${PICOTOOL_REPO} ${PICOTOOL_PATH}`, {
       stdout: process.stdout,
     })
     spinner.succeed()

--- a/src/toolbox/setup/pico/mac.ts
+++ b/src/toolbox/setup/pico/mac.ts
@@ -8,7 +8,7 @@ export async function installDeps(
   await ensureHomebrew()
 
   spinner.start('Tapping ArmMbed formulae and installing arm-embed-gcc')
-  await system.exec('brew tap ArmMbed/homebrew-formulae')
-  await system.exec(`brew install arm-none-eabi-gcc libusb pkg-config`)
+  await system.exec('brew tap ArmMbed/homebrew-formulae', { shell: process.env.SHELL })
+  await system.exec(`brew install arm-none-eabi-gcc libusb pkg-config`, { shell: process.env.SHELL })
   spinner.succeed()
 }

--- a/src/toolbox/setup/pico/mac.ts
+++ b/src/toolbox/setup/pico/mac.ts
@@ -1,15 +1,13 @@
 import type { GluegunPrint } from 'gluegun'
 import { system } from 'gluegun'
+import { ensureHomebrew } from '../homebrew';
 
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
-  if (system.which('brew') === null) {
-    print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
-  If you don't want to use Homebrew, please install python, cmake, ninja, and dfu-util manually before trying this command again.`)
-    process.exit(1);
-  }
+  await ensureHomebrew()
 
+  spinner.start('Tapping ArmMbed formulae and installing arm-embed-gcc')
   await system.exec('brew tap ArmMbed/homebrew-formulae')
   await system.exec(`brew install arm-none-eabi-gcc libusb pkg-config`)
   spinner.succeed()

--- a/src/toolbox/setup/pico/mac.ts
+++ b/src/toolbox/setup/pico/mac.ts
@@ -1,11 +1,17 @@
-import type { GluegunPrint } from 'gluegun'
-import { system } from 'gluegun'
+import { GluegunPrint, print, system } from 'gluegun'
 import { ensureHomebrew } from '../homebrew';
 
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
-  await ensureHomebrew()
+  try {
+    await ensureHomebrew()
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      print.info(`${error.message} arm-none-eabi-gcc, libusb, pkg-config`)
+      process.exit(1);
+    }
+  }
 
   spinner.start('Tapping ArmMbed formulae and installing arm-embed-gcc')
   await system.exec('brew tap ArmMbed/homebrew-formulae', { shell: process.env.SHELL })

--- a/src/toolbox/setup/pico/mac.ts
+++ b/src/toolbox/setup/pico/mac.ts
@@ -4,6 +4,12 @@ import { system } from 'gluegun'
 export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
+  if (system.which('brew') === null) {
+    print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
+  If you don't want to use Homebrew, please install python, cmake, ninja, and dfu-util manually before trying this command again.`)
+    process.exit(1);
+  }
+
   await system.exec('brew tap ArmMbed/homebrew-formulae')
   await system.exec(`brew install arm-none-eabi-gcc libusb pkg-config`)
   spinner.succeed()

--- a/src/toolbox/setup/wasm.ts
+++ b/src/toolbox/setup/wasm.ts
@@ -84,6 +84,12 @@ export default async function(): Promise<void> {
 
   if (system.which('cmake') === null) {
     if (OS === 'darwin') {
+      if (system.which('brew') === null) {
+        print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
+  If you don't want to use Homebrew, please install cmake manually before trying this command again.`)
+        process.exit(1);
+      }
+
       spinner.start('Cmake required, installing with Homebrew')
       await system.exec('brew install cmake')
     }

--- a/src/toolbox/setup/wasm.ts
+++ b/src/toolbox/setup/wasm.ts
@@ -88,7 +88,7 @@ export default async function(): Promise<void> {
       await ensureHomebrew()
 
       spinner.start('Cmake required, installing with Homebrew')
-      await system.exec('brew install cmake')
+      await system.exec('brew install cmake', { shell: process.env.SHELL })
     }
 
     if (OS === 'linux') {

--- a/src/toolbox/setup/wasm.ts
+++ b/src/toolbox/setup/wasm.ts
@@ -4,6 +4,7 @@ import { INSTALL_DIR, EXPORTS_FILE_PATH } from './constants'
 import { moddableExists } from './moddable'
 import upsert from '../patching/upsert'
 import { execWithSudo } from '../system/exec'
+import { ensureHomebrew } from './homebrew'
 
 export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
@@ -29,7 +30,7 @@ export default async function(): Promise<void> {
   // 1. Clone EM_SDK repo, install, and activate latest version
   if (filesystem.exists(EMSDK_PATH) === false) {
     spinner.start('Cloning emsdk repo')
-    await system.spawn(`git clone ${EMSDK_REPO} ${EMSDK_PATH}`)
+    await system.spawn(`git clone --depth 1 --single-branch -b main ${EMSDK_REPO} ${EMSDK_PATH}`)
     spinner.succeed()
   }
 
@@ -77,18 +78,14 @@ export default async function(): Promise<void> {
   if (filesystem.exists(BINARYEN_PATH) === false) {
     spinner.start('Cloning binaryen repo')
     await system.spawn(
-      `git clone --recursive ${BINARYEN_REPO} ${BINARYEN_PATH}`
+      `git clone --depth 1 --single-branch -b main --recursive ${BINARYEN_REPO} ${BINARYEN_PATH}`
     )
     spinner.succeed()
   }
 
   if (system.which('cmake') === null) {
     if (OS === 'darwin') {
-      if (system.which('brew') === null) {
-        print.error(`Homebrew is required to install necessary dependencies. Visit https://brew.sh/ to learn more about installing Homebrew.
-  If you don't want to use Homebrew, please install cmake manually before trying this command again.`)
-        process.exit(1);
-      }
+      await ensureHomebrew()
 
       spinner.start('Cmake required, installing with Homebrew')
       await system.exec('brew install cmake')

--- a/src/toolbox/setup/wasm.ts
+++ b/src/toolbox/setup/wasm.ts
@@ -85,7 +85,14 @@ export default async function(): Promise<void> {
 
   if (system.which('cmake') === null) {
     if (OS === 'darwin') {
-      await ensureHomebrew()
+      try {
+        await ensureHomebrew()
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          print.info(`${error.message} cmake`)
+          process.exit(1);
+        }
+      }
 
       spinner.start('Cmake required, installing with Homebrew')
       await system.exec('brew install cmake', { shell: process.env.SHELL })


### PR DESCRIPTION
Fixes #77 

----

The currently error handling for ensuring Homebrew is available suggests users to visit https://brew.sh/ and follow the instructions there. This is another prompt that can handle this task automatically if the user chooses. 