### PR TITLE
fix(setup): install to a temp directory and then swap (Windows)

### DIFF
--- a/src/toolbox/setup/constants.ts
+++ b/src/toolbox/setup/constants.ts
@@ -9,6 +9,7 @@ export const HOME_DIR = filesystem.homedir()
 export const INSTALL_DIR = isWindows ? filesystem.resolve(HOME_DIR, 'xs-dev') : filesystem.resolve(HOME_DIR, '.local', 'share')
 export const INSTALL_PATH =
   process.env.MODDABLE ?? filesystem.resolve(INSTALL_DIR, 'moddable')
+export const TEMP_PATH = filesystem.resolve(INSTALL_DIR, "xs-dev-temp")
 export const EXPORTS_FILE_PATH = isWindows ? 
 filesystem.resolve(INSTALL_DIR, "Moddable.bat") :
 filesystem.resolve(

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -151,7 +151,7 @@ export default async function (_args: SetupArgs): Promise<void> {
   
   // 1. clone moddable repo into INSTALL_DIR directory if it does not exist yet
 
-  if (filesystem.exists(TEMP_PATH))
+  if (filesystem.exists(TEMP_PATH) !== false)
     filesystem.remove(TEMP_PATH)
 
   try {


### PR DESCRIPTION
This PR is an attempt to address the problem discussed in #73 on Windows. It does this by cloning the Moddable SDK into a temporary directory, building the Moddable SDK tools there, and then swapping the temp directory to the permanent location when complete.

If we like this approach, it could be applied to the other host platform tool setups, ESP32/ESP8266 setup, etc.