### PR TITLE
fix: update source for esp8266 toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^19.0.3",
-    "axios": "^0.24.0",
+    "axios": "^1.2.1",
     "gluegun": "^5.1.2",
     "serialport": "^10.3.0",
     "serve-handler": "^6.1.3",
@@ -88,7 +88,7 @@
     "testEnvironment": "node"
   },
   "volta": {
-    "node": "16.14.0"
+    "node": "18.12.1"
   },
   "prettier": {
     "semi": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.33.0
   '@webcomponents/template-shadowroot': ^0.1.0
   astro: ^1.0.8
-  axios: ^0.24.0
+  axios: ^1.2.1
   eslint: ^7.32.0
   eslint-config-prettier: ^8.3.0
   eslint-config-standard-with-typescript: ^21.0.1
@@ -53,7 +53,7 @@ specifiers:
 
 dependencies:
   '@octokit/rest': 19.0.3
-  axios: 0.24.0
+  axios: 1.2.1
   gluegun: 5.1.2
   serialport: 10.3.0
   serve-handler: 6.1.3
@@ -2310,8 +2310,7 @@ packages:
     dev: false
 
   /asynckit/0.4.0:
-    resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=}
-    dev: true
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   /autoprefixer/10.4.7_postcss@8.4.14:
     resolution: {integrity: sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==}
@@ -2332,15 +2331,17 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.7
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /axios/0.24.0:
-    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
+  /axios/1.2.1:
+    resolution: {integrity: sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==}
     dependencies:
-      follow-redirects: 1.14.7
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2813,7 +2814,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /comma-separated-tokens/2.0.2:
     resolution: {integrity: sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg==}
@@ -3023,9 +3023,8 @@ packages:
     dev: true
 
   /delayed-stream/1.0.0:
-    resolution: {integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=}
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /deprecation/2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
@@ -4200,8 +4199,8 @@ packages:
     resolution: {integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==}
     dev: true
 
-  /follow-redirects/1.14.7:
-    resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -4218,6 +4217,15 @@ packages:
       combined-stream: 1.0.8
       mime-types: 2.1.34
     dev: true
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.34
+    dev: false
 
   /format/0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -6450,7 +6458,6 @@ packages:
   /mime-db/1.51.0:
     resolution: {integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /mime-types/2.1.18:
     resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
@@ -6464,7 +6471,6 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.51.0
-    dev: true
 
   /mime/3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -7128,6 +7134,10 @@ packages:
   /property-information/6.1.1:
     resolution: {integrity: sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==}
     dev: true
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
 
   /pseudomap/1.0.2:
     resolution: {integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=}

--- a/src/toolbox/setup/esp8266.ts
+++ b/src/toolbox/setup/esp8266.ts
@@ -21,7 +21,7 @@ const finishedPromise = promisify(finished)
 export default async function(): Promise<void> {
   const OS = platformType().toLowerCase() as Device
   const isWindows = OS === "windows_nt"
-  const TOOLCHAIN = isWindows ? 'https://www.dropbox.com/s/edbtq6oi1up623i/esp8266.toolchain.win32.zip?dl=1' : `https://www.moddable.com/private/esp8266.toolchain.${OS}.tgz`
+  const TOOLCHAIN = `https://github.com/Moddable-OpenSource/tools/releases/download/v1.0.0/esp8266.toolchain.${isWindows ? 'win32' : OS}.tgz`
   const ARDUINO_CORE =
     'https://github.com/esp8266/Arduino/releases/download/2.3.0/esp8266-2.3.0.zip'
   const ESP_RTOS_REPO = 'https://github.com/espressif/ESP8266_RTOS_SDK.git'
@@ -54,22 +54,13 @@ export default async function(): Promise<void> {
   if (filesystem.exists(TOOLCHAIN_PATH) === false) {
     spinner.start('Downloading xtensa toolchain')
 
-    if (isWindows) {
-      const writer = ZipExtract({ path: ESP_DIR })
-      const response = await axios.get(TOOLCHAIN, {
-        responseType: 'stream'
-      })
-      response.data.pipe(writer)
-      await finishedPromise(writer)
-    } else {
-      const writer = extract(ESP_DIR, { readable: true })
-      const gunzip = createGunzip()
-      const response = await axios.get(TOOLCHAIN, {
-        responseType: 'stream',
-      })
-      response.data.pipe(gunzip).pipe(writer)
-      await finishedPromise(writer)
-    }
+    const writer = extract(ESP_DIR, { readable: true })
+    const gunzip = createGunzip()
+    const response = await axios.get(TOOLCHAIN, {
+      responseType: 'stream',
+    })
+    response.data.pipe(gunzip).pipe(writer)
+    await finishedPromise(writer)
     spinner.succeed()
   }
 

--- a/src/toolbox/setup/esp8266/windows.ts
+++ b/src/toolbox/setup/esp8266/windows.ts
@@ -11,7 +11,7 @@ const finishedPromise = promisify(finished)
 
 const ESP_TOOL = 'https://github.com/igrr/esptool-ck/releases/download/0.4.13/esptool-0.4.13-win32.zip'
 const ESP_TOOL_VERSION = 'esptool-0.4.13-win32'
-const CYGWIN = 'https://www.dropbox.com/s/ub7xehxbf747eu1/cygwin.win32.zip?dl=1'
+const CYGWIN = `https://github.com/Moddable-OpenSource/tools/releases/download/v1.0.0/cygwin.win32.zip`
 
 export async function installPython(spinner: ReturnType<GluegunPrint['spin']>): Promise<void> {
   if (system.which('python') === null) {


### PR DESCRIPTION
Fixes #76 

Confirmed this works on Linux and Mac. I also updated the `axios` dependency to the stable v1+ and pinned the version of node used in this project to 18.12.1 (current LTS). The CLI will continue to support maintenance & LTS versions of NodeJS until they are removed from [support by the core project](https://github.com/nodejs/release#release-schedule). 