### PR TITLE
feat(mac): try mac universal binaries in setup/update

### DIFF
--- a/.changeset/stale-cars-sniff.md
+++ b/.changeset/stale-cars-sniff.md
@@ -1,0 +1,5 @@
+---
+'xs-dev': minor
+---
+
+Try downloading unversial mac binary from new SDK releases

--- a/src/toolbox/setup/moddable.ts
+++ b/src/toolbox/setup/moddable.ts
@@ -74,6 +74,12 @@ export async function fetchLatestRelease(): Promise<GitHubRelease> {
   return latestRelease
 }
 
+export class MissingReleaseAssetError extends Error {
+  constructor(assetName: string) {
+    super(`Unabled to find release asset matching ${assetName}`);
+  }
+}
+
 interface DownloadToolsArgs {
   writePath: string
   assetName: string
@@ -88,7 +94,7 @@ export async function downloadReleaseTools({
   const moddableTools = release.assets.find(({ name }) => name === assetName)
 
   if (moddableTools === undefined) {
-    throw new Error(`Unable to find release asset matching ${assetName}`)
+    throw new MissingReleaseAssetError(assetName);
   }
 
   const zipWriter = ZipExtract({


### PR DESCRIPTION
As informed by @mkellner, the latest Moddable release includes a universal prebuilt binary for MacOS alongside the arch-specific builds. This PR adds logic to the setup and update commands to try using that universal binary if available before falling back to the arch-specific targets. 

