### PR TITLE
Add optional configuration arguments to build and run commands

### DIFF
--- a/docs/src/pages/en/features/run.md
+++ b/docs/src/pages/en/features/run.md
@@ -62,6 +62,13 @@ xs-dev run --port /dev/cu.usbserial-0001 --device esp8266
 
 _This value can be discovered using the [`scan`](./scan) command._
 
+## Set `mc/config` arguments
+
+Use the `--config` flag to provide [config arguments](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/tools/tools.md#arguments) to the `mc/config` module. This mechanism is often used to configure Wi-Fi credentials when running on a device:
+
+```
+xs-dev run --example network/http/httpgetjson --device esp32 --config.ssid=mySSID --config.password="a secret"
+```
 
 ## Building projects for release
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -14,7 +14,7 @@ interface BuildOptions {
   mode?: Mode
   output?: string
   deploy?: boolean
-  config?: object
+  config?: Record<string, string>
 }
 
 const command: GluegunCommand<XSDevToolbox> = {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -14,6 +14,7 @@ interface BuildOptions {
   mode?: Mode
   output?: string
   deploy?: boolean
+  config?: object
 }
 
 const command: GluegunCommand<XSDevToolbox> = {
@@ -30,6 +31,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       mode = (process.env.NODE_ENV as Mode) ?? 'development',
       output = '',
       deploy = false,
+      config = {}
     }: BuildOptions = parameters.options
     const targetPlatform: string = DEVICE_ALIAS[device] ?? device
     const projectPath = filesystem.resolve(parameters.first ?? '.')
@@ -47,6 +49,7 @@ const command: GluegunCommand<XSDevToolbox> = {
         output !== ''
           ? filesystem.resolve(output)
           : filesystem.resolve(String(process.env.MODDABLE), 'build'),
+      config
     })
   },
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -13,6 +13,7 @@ interface RunOptions {
   listDevices?: boolean
   mode?: Mode
   output?: string
+  config?: object
 }
 
 const command: GluegunCommand<XSDevToolbox> = {
@@ -28,6 +29,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       listDevices = false,
       mode = (process.env.NODE_ENV as Mode) ?? 'development',
       output = filesystem.resolve(String(process.env.MODDABLE), 'build'),
+      config = {}
     }: RunOptions = parameters.options
     const targetPlatform: string = DEVICE_ALIAS[device] ?? device
     const projectPath = filesystem.resolve(parameters.first ?? '.')
@@ -42,6 +44,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       mode,
       deployStatus: 'run',
       outputDir: output,
+      config
     })
   },
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -13,7 +13,7 @@ interface RunOptions {
   listDevices?: boolean
   mode?: Mode
   output?: string
-  config?: object
+  config?: Record<string, string>
 }
 
 const command: GluegunCommand<XSDevToolbox> = {

--- a/src/toolbox/build/index.ts
+++ b/src/toolbox/build/index.ts
@@ -19,7 +19,7 @@ export interface BuildArgs {
   mode: 'development' | 'production'
   deployStatus: DeployStatus
   outputDir: string
-  config?: object
+  config?: Record<string, string>
 }
 
 export async function build({
@@ -214,8 +214,8 @@ export async function build({
   if (mode === 'development') configArgs.push('-d')
   if (mode === 'production') configArgs.push('-i')
 
-  Object.keys(config).forEach(element => {
-    configArgs.push(`${element}="${config[element as keyof typeof config] as string}"`)
+  Object.entries(config).forEach(([element, value]) => {
+    configArgs.push(`${element}="${value}"`)
   })
 
   await system.exec(`mcconfig ${configArgs.join(' ')}`, {

--- a/src/toolbox/build/index.ts
+++ b/src/toolbox/build/index.ts
@@ -19,6 +19,7 @@ export interface BuildArgs {
   mode: 'development' | 'production'
   deployStatus: DeployStatus
   outputDir: string
+  config?: object
 }
 
 export async function build({
@@ -31,6 +32,7 @@ export async function build({
   mode,
   deployStatus,
   outputDir,
+  config = {}
 }: BuildArgs): Promise<void> {
   const OS = platformType().toLowerCase() as Device
 
@@ -212,9 +214,14 @@ export async function build({
   if (mode === 'development') configArgs.push('-d')
   if (mode === 'production') configArgs.push('-i')
 
+  Object.keys(config).forEach(element => {
+    configArgs.push(`${element}="${config[element as keyof typeof config] as string}"`)
+  })
+
   await system.exec(`mcconfig ${configArgs.join(' ')}`, {
     cwd: projectPath,
     process,
+    shell: true
   })
 
   if (deployStatus === 'push') {


### PR DESCRIPTION
This PR addresses issue #101. 

It implements the last suggestion by @phoddie, allowing `--config.ssid=MyWiFi` and `--config.password="a secret"`.

The change to add `shell: true` to the call to `system.exec` was necessary to preserve quotes around configuration items on Windows without weird escaping issues.

I welcome suggestions from TypeScript experts on how to better accomplish this while still keeping the linter happy 😆: 

```typescript
configArgs.push(`${element}="${config[element as keyof typeof config] as string}"`)`
```
