### PR TITLE
feat: automatically source environment variables into process

### DIFF
--- a/docs/src/pages/en/features/setup.md
+++ b/docs/src/pages/en/features/setup.md
@@ -28,6 +28,10 @@ A symlink for [`xsbug.app`](https://github.com/Moddable-OpenSource/moddable/blob
 
 The [`moddable` git repo](https://github.com/Moddable-OpenSource/moddable) is cloned into `~/.local/share` instead of a new/existing `~/Projects` directory.
 
+**Environment config:**
+
+This command will create (and update) an environment configuration file called `~/.local/share/xs-dev-export.sh` (on Mac & Linux) or `Moddable.bat` (on Windows). This file will be placed in the shell setup file (`.profile`, `.zshrc`, `.bashrc`, etc on Mac & Linux) or the custom command prompt (on Windows), to set environment variables and call other "exports" files for embedded tooling.
+
 ## Target Branch
 
 The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -45,10 +45,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       projectPath,
       mode,
       deployStatus: deploy ? 'push' : 'none',
-      outputDir:
-        output !== ''
-          ? filesystem.resolve(output)
-          : filesystem.resolve(String(process.env.MODDABLE), 'build'),
+      outputDir: output,
       config
     })
   },

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,6 +2,7 @@ import type { GluegunCommand } from 'gluegun'
 import os from 'os'
 import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 import { getModdableVersion, moddableExists } from '../toolbox/setup/moddable'
+import { sourceEnvironment } from '../toolbox/system/exec'
 import { detectPython, getPythonVersion } from '../toolbox/system/python'
 import { Device } from '../types'
 
@@ -11,6 +12,8 @@ const command: GluegunCommand = {
   alias: ['dr', 'info'],
   description: 'Display the current environment setup information, including valid target devices.',
   run: async ({ print, meta, filesystem, system }) => {
+    await sourceEnvironment()
+
     const supportedDevices = []
 
     if (moddableExists()) {
@@ -46,6 +49,7 @@ const command: GluegunCommand = {
       ['CLI Version', meta.version()],
       ['OS', os.type()],
       ['Arch', os.arch()],
+      ['Shell', process.env.SHELL ?? 'Unknown'],
       ['NodeJS Version', `${process.version} (${system.which('node') ?? 'path not found'})`],
       ['Python Version', `${pythonVersion} (${pythonPath})`],
       ['Moddable SDK Version', `${moddableVersion} (${moddablePath})`],

--- a/src/commands/include.ts
+++ b/src/commands/include.ts
@@ -1,5 +1,6 @@
 import type { GluegunCommand } from 'gluegun'
 import { collectChoicesFromTree } from '../toolbox/prompt/choices'
+import { sourceEnvironment } from '../toolbox/system/exec'
 
 interface IncludeOptions {
   device?: string
@@ -16,6 +17,9 @@ const command: GluegunCommand = {
       )
       process.exit(1)
     }
+
+    await sourceEnvironment()
+
     const modulesPath = filesystem.resolve(
       String(process.env.MODDABLE),
       'modules'
@@ -52,7 +56,7 @@ const command: GluegunCommand = {
     print.info(`Adding "${String(moduleName)}" to manifest includes`)
     const modulePath = `$(MODDABLE)/modules/${String(moduleName)}/manifest.json`
     await patching.update(manifestPath, (manifestIn) => {
-      let  manifest = manifestIn
+      let manifest = manifestIn
       if (device !== "") {
         manifest.platforms ??= {}
         manifest.platforms[device] ??= {}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,6 @@
 import type { GluegunCommand } from 'gluegun'
 import { collectChoicesFromTree } from '../toolbox/prompt/choices'
+import { sourceEnvironment } from '../toolbox/system/exec'
 
 interface InitOptions {
   typescript?: boolean
@@ -38,6 +39,9 @@ const command: GluegunCommand = {
         )
         process.exit(0)
       }
+
+      await sourceEnvironment()
+
       if (example !== false) {
         // find example project
         const exampleProjectPath = filesystem.resolve(
@@ -55,14 +59,14 @@ const command: GluegunCommand = {
           const filteredChoices = choices.filter((choice) =>
             choice.includes(String(example))
           )
-          ;({ example: selectedExample } = await prompt.ask([
-            {
-              type: 'autocomplete',
-              name: 'example',
-              message: 'Here are the available examples templates:',
-              choices: filteredChoices.length > 0 ? filteredChoices : choices,
-            },
-          ]))
+            ; ({ example: selectedExample } = await prompt.ask([
+              {
+                type: 'autocomplete',
+                name: 'example',
+                message: 'Here are the available examples templates:',
+                choices: filteredChoices.length > 0 ? filteredChoices : choices,
+              },
+            ]))
         }
 
         // copy files into new project directory

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -30,7 +30,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       listDevices = false,
       log = false,
       mode = (process.env.NODE_ENV as Mode) ?? 'development',
-      output = filesystem.resolve(String(process.env.MODDABLE), 'build'),
+      output,
       config = {}
     }: RunOptions = parameters.options
     const targetPlatform: string = DEVICE_ALIAS[device] ?? device

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -3,6 +3,7 @@ import { findBySerialNumber } from 'usb'
 import type { GluegunCommand } from 'gluegun'
 import type { XSDevToolbox } from '../types'
 import { parseScanResult } from '../toolbox/scan/parse'
+import { sourceEnvironment } from '../toolbox/system/exec'
 
 // eslint-disable-next-line
 function sleep(timeout: number) {
@@ -21,6 +22,8 @@ const command: GluegunCommand<XSDevToolbox> = {
       process.exit(0)
     }
 
+    await sourceEnvironment()
+
     if (system.which('esptool.py') === null) {
       print.warning(
         'esptool.py required to scan for Espressif devices. Setup environment for ESP8266 or ESP32:\n xs-dev setup --device esp32\n xs-dev setup --device esp8266.'
@@ -37,7 +40,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       try {
         await system.exec('picotool reboot -fa')
         await sleep(1000)
-      } catch {}
+      } catch { }
     }
 
     const ports = await SerialPort.list()
@@ -62,7 +65,7 @@ const command: GluegunCommand<XSDevToolbox> = {
             return await system
               .exec(`esptool.py --port ${port.path} read_mac`)
               .then((buffer) => [buffer, port.path])
-          } catch {}
+          } catch { }
           return [undefined, port.path]
         })
     )

--- a/src/toolbox/build/index.ts
+++ b/src/toolbox/build/index.ts
@@ -7,6 +7,7 @@ import { collectChoicesFromTree } from '../prompt/choices'
 import { moddableExists } from '../setup/moddable'
 import { DEVICE_ALIAS } from '../prompt/devices'
 import { Device } from '../../types'
+import { sourceEnvironment } from '../system/exec'
 
 export type DeployStatus = 'none' | 'run' | 'push'
 
@@ -20,7 +21,7 @@ export interface BuildArgs {
   targetPlatform: string
   mode: 'development' | 'production'
   deployStatus: DeployStatus
-  outputDir: string
+  outputDir?: string
   config?: Record<string, string>
 }
 
@@ -39,12 +40,16 @@ export async function build({
 }: BuildArgs): Promise<void> {
   const OS = platformType().toLowerCase() as Device
 
+  await sourceEnvironment()
+
   if (!moddableExists()) {
     print.error(
       `Moddable tooling required. Run 'xs-dev setup --device ${DEVICE_ALIAS[OS]}' before trying again.`
     )
     process.exit(1)
   }
+
+  outputDir ??= filesystem.resolve(String(process.env.MODDABLE), 'build')
 
   if (listDevices) {
     const choices = [

--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -7,6 +7,7 @@ import { installDeps as installMacDeps } from './esp32/mac'
 import { installDeps as installLinuxDeps } from './esp32/linux'
 import { installDeps as installWinDeps } from './esp32/windows'
 import { setEnv, ensureModdableCommandPrompt } from './windows'
+import { sourceEnvironment } from '../system/exec'
 
 export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
@@ -15,6 +16,8 @@ export default async function(): Promise<void> {
   const ESP_BRANCH = 'v4.4.2'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
+
+  await sourceEnvironment()
 
   const spinner = print.spin()
   spinner.start('Setting up esp32 tools')

--- a/src/toolbox/setup/esp8266.ts
+++ b/src/toolbox/setup/esp8266.ts
@@ -15,6 +15,7 @@ import { installDeps as installWindowsDeps } from './esp8266/windows'
 import { ensureModdableCommandPrompt } from './windows'
 import { DEVICE_ALIAS } from '../prompt/devices'
 import { Device } from '../../types'
+import { sourceEnvironment } from '../system/exec'
 
 const finishedPromise = promisify(finished)
 
@@ -30,6 +31,8 @@ export default async function(): Promise<void> {
   const RTOS_PATH = filesystem.resolve(ESP_DIR, 'ESP8266_RTOS_SDK')
   const TOOLCHAIN_PATH = filesystem.resolve(ESP_DIR, 'toolchain')
   const ARDUINO_CORE_PATH = filesystem.resolve(ESP_DIR, 'esp8266-2.3.0')
+
+  await sourceEnvironment()
 
   const spinner = print.spin()
   spinner.start('Setting up esp8266 tools')

--- a/src/toolbox/setup/pico.ts
+++ b/src/toolbox/setup/pico.ts
@@ -5,6 +5,7 @@ import upsert from '../patching/upsert'
 import { installDeps as installMacDeps } from './pico/mac'
 import { installDeps as installLinuxDeps } from './pico/linux'
 import { moddableExists } from './moddable'
+import { sourceEnvironment } from '../system/exec'
 
 export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
@@ -18,6 +19,8 @@ export default async function(): Promise<void> {
   const PICOTOOL_BUILD_DIR = filesystem.resolve(PICOTOOL_PATH, 'build')
   const PICO_SDK_BUILD_DIR = filesystem.resolve(PICO_SDK_DIR, 'build')
   const PIOASM_PATH = filesystem.resolve(PICO_SDK_BUILD_DIR, 'pioasm', 'pioasm')
+
+  await sourceEnvironment()
 
   const spinner = print.spin()
   spinner.start('Starting pico tooling setup')

--- a/src/toolbox/setup/wasm.ts
+++ b/src/toolbox/setup/wasm.ts
@@ -3,7 +3,7 @@ import { type as platformType } from 'os'
 import { INSTALL_DIR, EXPORTS_FILE_PATH } from './constants'
 import { moddableExists } from './moddable'
 import upsert from '../patching/upsert'
-import { execWithSudo } from '../system/exec'
+import { execWithSudo, sourceEnvironment } from '../system/exec'
 import { ensureHomebrew } from './homebrew'
 
 export default async function(): Promise<void> {
@@ -13,6 +13,8 @@ export default async function(): Promise<void> {
   const WASM_DIR = filesystem.resolve(INSTALL_DIR, 'wasm')
   const EMSDK_PATH = filesystem.resolve(WASM_DIR, 'emsdk')
   const BINARYEN_PATH = filesystem.resolve(WASM_DIR, 'binaryen')
+
+  await sourceEnvironment()
 
   const spinner = print.spin({ stream: process.stdout })
   spinner.start('Setting up wasm simulator tools')

--- a/src/toolbox/update/esp32.ts
+++ b/src/toolbox/update/esp32.ts
@@ -5,12 +5,15 @@ import { moddableExists } from '../setup/moddable'
 import upsert from '../patching/upsert'
 import { installDeps as installMacDeps } from '../setup/esp32/mac'
 import { installDeps as installLinuxDeps } from '../setup/esp32/linux'
+import { sourceEnvironment } from '../system/exec'
 
-export default async function (): Promise<void> {
+export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
   const ESP_BRANCH = 'v4.4.2'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
+
+  await sourceEnvironment()
 
   const spinner = print.spin()
   spinner.start('Updating up esp32 tools')

--- a/src/toolbox/update/linux.ts
+++ b/src/toolbox/update/linux.ts
@@ -9,11 +9,14 @@ import {
   moddableExists,
   downloadReleaseTools,
 } from '../setup/moddable'
-import { execWithSudo } from '../system/exec'
+import { execWithSudo, sourceEnvironment } from '../system/exec'
 
 const chmodPromise = promisify(chmod)
 
 export default async function({ targetBranch }: SetupArgs): Promise<void> {
+
+  await sourceEnvironment()
+
   // 0. ensure Moddable exists
   if (!moddableExists()) {
     print.error(

--- a/src/toolbox/update/mac.ts
+++ b/src/toolbox/update/mac.ts
@@ -10,11 +10,14 @@ import {
   MissingReleaseAssetError,
 } from '../setup/moddable'
 import { SetupArgs } from '../setup/types'
+import { sourceEnvironment } from '../system/exec'
 
 const chmodPromise = promisify(chmod)
 
 export default async function({ targetBranch }: SetupArgs): Promise<void> {
   print.info('Checking for SDK changes')
+
+  await sourceEnvironment()
 
   // 0. ensure Moddable exists
   if (!moddableExists()) {


### PR DESCRIPTION
Fixes #110 🤞 

Following the suggestion from @phoddie, this PR adds an additional step to various commands to update the `process.env` object with information from the user shell after manually "sourcing" the `xs-dev-exports` file on Unix-like systems. This appears to allow running examples immediately after setup without creating a new shell session. 

This PR also adds a "Shell" field to the output of `xs-dev info` to help with debugging; as well as, an "Environment config" section of the `setup` docs page to provide more info about the use of the "exports" file. 