### PR TITLE
fix(exec): check for buffer response from stdout, convert to string

### DIFF
--- a/docs/src/pages/en/guide/01-hello-console.md
+++ b/docs/src/pages/en/guide/01-hello-console.md
@@ -60,3 +60,23 @@ This will keep running until the `Ctrl+C` keys are entered in the terminal sessi
 
 Use the `--list-examples` flag with the `run` command to search the extensive list of available examples to run in the simulator: `xs-dev run --list-examples`
 
+## Troubleshooting
+
+When attempting to run the Hello World example, if you continually see the following error (even after starting a new terminal session):
+
+```
+Moddable tooling required. Run 'xs-dev setup --device <computer os here>' before trying again.
+```
+
+There may be an issue with the terminal shell or command prompt using the correct [environment configuration](/xs-dev/en/features/setup#overview) for xs-dev.
+
+- [Learn about Terminal profiles on MacOS](https://support.apple.com/guide/terminal/default-startup-terminal-window-profiles-trml5856b1f2/mac)
+- [Learn about shell initialization files and user profiles on Linux](https://www.tecmint.com/understanding-shell-initialization-files-and-user-profiles-linux/)
+- [Learn about Windows Terminal startup settings](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/startup)
+
+On "Unix-like" environments (MacOS, Linux), the `env` command should contain a reference to the `MODDABLE` environment variable:
+
+```
+env | grep MODDABLE
+```
+The above command should return something like `MODDABLE=/Users/<username>/.local/share/moddable` to indicate where the Moddable SDK has been installed in the filesystem.

--- a/docs/src/pages/en/introduction.md
+++ b/docs/src/pages/en/introduction.md
@@ -30,6 +30,10 @@ The Moddable SDK and associated dev board tooling is incredibly empowering for e
 - [-] Windows (currently in beta)
 - [X] Linux
 
+**Check out the getting started video from the Moddable team**
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/1gxFWBnDl18" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ## Requirements
 
 [Node.js >= v14](https://nodejs.org/en/)
@@ -69,3 +73,4 @@ pnpm update -g xs-dev
 ```
 yarn global upgrade xs-dev
 ```
+

--- a/src/toolbox/system/exec.ts
+++ b/src/toolbox/system/exec.ts
@@ -48,8 +48,8 @@ export async function sourceEnvironment(): Promise<void> {
       const result = await system.spawn(`source ${EXPORTS_FILE_PATH} && env`, {
         shell: process.env.SHELL,
       })
-      if (typeof result.stdout === 'string') {
-        const localEnv = Object.fromEntries(result.stdout.split('\n').map((field: string) => field?.split('=')))
+      if (typeof result.stdout === 'string' || result.stdout instanceof Buffer) {
+        const localEnv = Object.fromEntries(result.stdout.toString().split('\n').map((field: string) => field?.split('=')))
         if ('PATH' in localEnv) process.env = localEnv
       }
     } catch (error) {


### PR DESCRIPTION
I did some debugging for the "environment sourcing" fix from #112 and found a case where the `spawn` process returns a Buffer instead of a string. With this case handled, this should work better for folks.

This PR also includes some documentation updates:
Introduction video on the homepage
![image](https://user-images.githubusercontent.com/3051193/226488598-54b46ff7-3cf7-45be-bbdc-0999d6076ff2.png)
Troubleshooting section in the "Hello Console" guide
![image](https://user-images.githubusercontent.com/3051193/226488649-020a2d36-ecde-4cbb-a55f-709b94b75b2a.png)
