### PR TITLE
feat(setup): add --source-repo flag for custom SDK repo config

### DIFF
--- a/docs/src/pages/en/features/setup.md
+++ b/docs/src/pages/en/features/setup.md
@@ -36,10 +36,16 @@ This command will create (and update) an environment configuration file called `
 
 The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 
 
-To override this behavior, use the `--target-branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools.
+To override this behavior, use the `--target-branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools. This can be set to any branch name, however `public` is the main public branch for the Moddable-OpenSource repo.
 
 ```
 xs-dev setup --target-branch public
+```
+
+When combined with the `--source-repo` flag, it's possible to get the SDK repo from another source instead of the default GitHub repo.
+
+```
+xs-dev setup --source-repo https://my-sdk.moddable-git.not-real --target-branch main
 ```
 
 _This will only work for the `mac`, `windows`, and `linux` device options, which are the respective defaults for the operating system on which the command is run._

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -3,12 +3,15 @@ import { type as platformType } from 'os'
 import type { Device, XSDevToolbox } from '../types'
 import setupFontbm from '../toolbox/setup/fontbm'
 import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
+import { MODDABLE_REPO } from '../toolbox/setup/constants'
+import { SetupArgs } from '../toolbox/setup/types'
 
 interface SetupOptions {
   device?: Device
   listDevices?: boolean
   tool?: string
-  targetBranch?: 'public' | 'latest-release'
+  targetBranch?: SetupArgs['targetBranch']
+  sourceRepo?: string
 }
 
 const command: GluegunCommand<XSDevToolbox> = {
@@ -22,6 +25,7 @@ const command: GluegunCommand<XSDevToolbox> = {
       listDevices = false,
       tool,
       targetBranch = 'latest-release',
+      sourceRepo = MODDABLE_REPO,
     }: SetupOptions = parameters.options
     let target: Device = device ?? currentPlatform
 
@@ -58,8 +62,12 @@ const command: GluegunCommand<XSDevToolbox> = {
       await setupFontbm()
       return
     }
-
-    await setup[target]({ targetBranch })
+    const platformDevices: Device[] = ['mac', 'darwin', 'windows_nt', 'win', 'lin', 'linux']
+    if (platformDevices.includes(target)) {
+      await setup[target]({ targetBranch, sourceRepo })
+    } else {
+      await setup[target]({ targetBranch })
+    }
   },
 }
 

--- a/src/toolbox/setup/types.ts
+++ b/src/toolbox/setup/types.ts
@@ -1,3 +1,7 @@
 export interface SetupArgs {
-  targetBranch: 'public' | 'latest-release'
+  targetBranch: 'public' | 'latest-release' | string
+}
+
+export interface PlatformSetupArgs extends SetupArgs {
+  sourceRepo: string;
 }

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -8,14 +8,13 @@ import {
 import {
   INSTALL_PATH,
   INSTALL_DIR,
-  MODDABLE_REPO,
   EXPORTS_FILE_PATH,
   XSBUG_LOG_PATH
 } from './constants'
 import upsert from '../patching/upsert'
 import ws from 'windows-shortcuts'
 import { promisify } from 'util'
-import { SetupArgs } from './types'
+import { PlatformSetupArgs } from './types'
 
 const wsPromise = promisify(ws.create)
 
@@ -48,7 +47,7 @@ export async function ensureModdableCommandPrompt(spinner: ReturnType<GluegunPri
   }
 }
 
-export default async function(_args: SetupArgs): Promise<void> {
+export default async function({ sourceRepo }: PlatformSetupArgs): Promise<void> {
   const BIN_PATH = filesystem.resolve(
     INSTALL_PATH,
     'build',
@@ -147,8 +146,8 @@ export default async function(_args: SetupArgs): Promise<void> {
     spinner.info('Moddable repo already installed')
   } else {
     try {
-      spinner.start('Cloning Moddable-OpenSource/moddable repo')
-      await system.spawn(`git clone ${MODDABLE_REPO} ${INSTALL_PATH}`)
+      spinner.start(`Cloning ${sourceRepo} repo`)
+      await system.spawn(`git clone ${sourceRepo} ${INSTALL_PATH}`)
       spinner.succeed()
     } catch (error) {
       spinner.fail(`Error cloning moddable repo: ${String(error)}`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { GluegunToolbox } from 'gluegun'
-import type { SetupArgs } from './toolbox/setup/types'
+import type { PlatformSetupArgs, SetupArgs } from './toolbox/setup/types'
 import type { BuildArgs } from './toolbox/build/index'
 
 export type Device =
@@ -18,7 +18,7 @@ export type Device =
 export interface XSDevToolbox extends GluegunToolbox {
   setup: Record<
     Device,
-    (() => Promise<void>) | ((args: SetupArgs) => Promise<void>)
+    (() => Promise<void>) | ((args: SetupArgs | PlatformSetupArgs) => Promise<void>)
   >
   update: Record<
     Device,


### PR DESCRIPTION
From the updated `setup` docs:

> ## Target Branch
>
>The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 
>
>To override this behavior, use the `--target-branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools. This can be set to any branch name, however `public` is the main public branch for the Moddable-OpenSource repo.
>
>```
>xs-dev setup --target-branch public
>```
>
>When combined with the `--source-repo` flag, it's possible to get the SDK repo from another source instead of the default GitHub repo.
>
>```
>xs-dev setup --source-repo https://my-sdk.moddable-git.not-real --target-branch main
>```
>
> _This will only work for the `mac`, `windows`, and `linux` device options, which are the respective defaults for the operating system on which the command is run._
