### PR TITLE
refactor(setup): abstract platform deps into json config

### DIFF
--- a/src/toolbox/setup/esp32/platform.json
+++ b/src/toolbox/setup/esp32/platform.json
@@ -1,0 +1,168 @@
+{
+  "name": "esp32",
+  "dependencies": {
+    "esp-idf": {
+      "type": "repo",
+      "source": "https://github.com/espressif/esp-idf.git",
+      "version": "v4.4.2",
+      "recursive": true,
+    },
+    "python": {
+      "version": "3"
+    },
+    "cmake": {
+      "type": "package",
+      "os": [
+        "mac",
+        "linux"
+      ],
+      "installer": {
+        "mac": "homebrew",
+        "linux": "apt"
+      }
+    },
+    "ninja": {
+      "type": "package",
+      "os": [
+        "mac"
+      ],
+      "installer": {
+        "mac": "homebrew"
+      }
+    },
+    "ninja-build": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "dfu-util": {
+      "type": "package",
+      "os": [
+        "mac"
+      ],
+      "installer": {
+        "mac": "homebrew",
+        "linux": "apt"
+      }
+    },
+    "pyserial": {
+      "type": "package",
+      "os": [
+        "mac"
+      ],
+      "installer": {
+        "mac": "pip"
+      }
+    },
+    "python3-serial": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "git": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "wget": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "flex": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "bison": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "gperf": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "python-is-python3": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "python-setuptools": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "ccache": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "libffi-dev": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "libssl-dev": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "esp-idf-tools-setup-online-2.15.exe": {
+      "type": "download",
+      "os": [
+        "windows"
+      ],
+      "source": "https://github.com/espressif/idf-installer/releases/download/online-2.15/esp-idf-tools-setup-online-2.15.exe"
+    }
+  }
+}

--- a/src/toolbox/setup/esp8266/platform.json
+++ b/src/toolbox/setup/esp8266/platform.json
@@ -1,0 +1,94 @@
+{
+  "name": "esp8266",
+  "dependencies": {
+    "ESP8266_RTOS_SDK": {
+      "type": "repo",
+      "source": "https://github.com/espressif/ESP8266_RTOS_SDK.git",
+      "version": "release/v3.2"
+    },
+    "toolchain": {
+      "type": "download",
+      "os": [
+        "mac",
+        "linux",
+        "windows"
+      ],
+      "source": {
+        "mac": "https://github.com/Moddable-OpenSource/tools/releases/download/v1.0.0/esp8266.toolchain.darwin.tgz",
+        "linux": "https://github.com/Moddable-OpenSource/tools/releases/download/v1.0.0/esp8266.toolchain.linux.tgz",
+        "windows": "https://github.com/Moddable-OpenSource/tools/releases/download/v1.0.0/esp8266.toolchain.win32.tgz"
+      }
+    },
+    "esp8266-2.3.0": {
+      "type": "download",
+      "os": [
+        "mac",
+        "linux",
+        "windows"
+      ],
+      "source": "https://github.com/esp8266/Arduino/releases/download/2.3.0/esp8266-2.3.0.zip"
+    },
+    "python": {
+      "type": "package",
+      "version": "3",
+      "os": [
+        "mac"
+      ],
+      "installer": {
+        "mac": "homebrew"
+      }
+    },
+    "Python.Python.3": {
+      "type": "package",
+      "os": [
+        "windows"
+      ],
+      "installer": {
+        "windows": "winget"
+      }
+    },
+    "pyserial": {
+      "type": "package",
+      "os": [
+        "mac",
+        "windows"
+      ],
+      "installer": {
+        "mac": "pip",
+        "windows": "pip"
+      }
+    },
+    "python3-serial": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "python-is-python3": {
+      "type": "package",
+      "os": [
+        "linux"
+      ],
+      "installer": {
+        "linux": "apt"
+      }
+    },
+    "esptool-0.4.13-win32": {
+      "type": "download",
+      "os": [
+        "windows"
+      ],
+      "source": "https://github.com/igrr/esptool-ck/releases/download/0.4.13/esptool-0.4.13-win32.zip"
+    },
+    "cygwin": {
+      "type": "download",
+      "os": [
+        "windows"
+      ],
+      "source": "https://github.com/Moddable-OpenSource/tools/releases/download/v1.0.0/cygwin.win32.zip"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4 and follow up to #117 

While I originally thought the [SBOM format](https://spdx.dev/specifications/) might be a standardize way to solve this, it didn't appear to satisfy my expected requirements. Instead, I looked to the [PlatformIO project](https://docs.platformio.org/en/latest/what-is-platformio.html) for inspiration. This lead me to their [`platform.json` manifest file](https://docs.platformio.org/en/latest/platforms/creating_platform.html#manifest-file-platform-json) to define platform definitions for integrating with the PlatformIO tooling. 

In this PR, I've adapted the `platform.json` idea into a fairly simple schema with a map of dependencies of various types ("repo", "package", "download") and other fields ("os", "source", "installer"). This should be able to cover the basic requirements for each platform.

TODO:
- [ ] create formal [JSON Schema](https://json-schema.org/) definition for validation
- [ ] create pico platform.json
- [ ] create fontbm platform.json
- [ ] create Moddable platform.json (?)
- [ ] refactor setup tasks to use platform.json schema
- [ ] determine how to fetch schema from Moddable as source of truth