### PR TITLE
fix(nrf52): make node-lzma an optional dep, handle dynamic import

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -38,6 +38,10 @@ export default defineConfig({
           label: 'Guide',
           autogenerate: { directory: 'guide' },
         },
+        {
+          label: 'Troubleshooting',
+          link: '/troubleshooting',
+        }
       ],
     }),
   ],

--- a/docs/src/content/docs/troubleshooting.md
+++ b/docs/src/content/docs/troubleshooting.md
@@ -1,0 +1,34 @@
+---
+title: Troubleshooting
+description: Tips for resolving known issues
+---
+
+## `symbol not found in flat namespace '_lzma_stream_encoder_mt'`
+
+Other error messages can include: 
+
+- "Unable to extract Arm Embedded Toolchain without XZ utils (https://tukaani.org/xz/). Please install that dependency on your system and reinstall xs-dev before attempting this setup again."
+
+If you encounter an error message related to lzma or node-lzma, this is likely due to a missing system dependency required to setup the tooling to program nrf52-based devices. This is only required on MacOS and Linux development environments.
+
+To resolve this, install the [XS Utils](https://tukaani.org/xz/) for your system.
+
+On MacOS, [Homebrew](https://brew.sh) can be used:
+
+```
+brew install xz
+```
+
+For Debian-based systems like Ubuntu:
+
+```
+sudo apt-get -y install xz-utils
+```
+
+If using `yum`:
+
+```
+sudo yum -y install xz
+```
+
+Once this is dependency has been installed, please re-install xs-dev to ensure the CLI is built correctly with the native bindings to xz-utils.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@octokit/rest": "^19.0.3",
     "axios": "^1.2.1",
     "gluegun": "^5.1.2",
-    "node-liblzma": "^1.1.9",
     "serialport": "^10.3.0",
     "serve-handler": "^6.1.3",
     "simple-plist": "^1.3.1",
@@ -52,6 +51,9 @@
     "unzip-stream": "^0.3.1",
     "usb": "^2.2.0",
     "windows-shortcuts": "^0.1.6"
+  },
+  "optionalDependencies": {
+    "node-liblzma": "^1.1.9"
   },
   "devDependencies": {
     "@astrojs/starlight": "^0.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ dependencies:
   gluegun:
     specifier: ^5.1.2
     version: 5.1.2
-  node-liblzma:
-    specifier: ^1.1.9
-    version: 1.1.9
   serialport:
     specifier: ^10.3.0
     version: 10.3.0
@@ -50,6 +47,11 @@ dependencies:
   windows-shortcuts:
     specifier: ^0.1.6
     version: 0.1.6
+
+optionalDependencies:
+  node-liblzma:
+    specifier: ^1.1.9
+    version: 1.1.9
 
 devDependencies:
   '@astrojs/starlight':
@@ -7595,7 +7597,9 @@ packages:
 
   /node-addon-api@4.2.0:
     resolution: {integrity: sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q==}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
@@ -7643,6 +7647,7 @@ packages:
       node-addon-api: 4.2.0
       node-gyp-build: 4.3.0
     dev: false
+    optional: true
 
   /node-releases@2.0.12:
     resolution: {integrity: sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==}

--- a/src/toolbox/setup/nrf52.ts
+++ b/src/toolbox/setup/nrf52.ts
@@ -6,9 +6,6 @@ import { finished } from 'stream'
 import { extract } from 'tar-fs'
 import { promisify } from 'util'
 import { Extract as ZipExtract } from 'unzip-stream'
-// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-// @ts-ignore
-import { createUnxz } from 'node-liblzma'
 import { Device } from '../../types'
 import { DEVICE_ALIAS } from '../prompt/devices'
 import { execWithSudo, sourceEnvironment } from '../system/exec'
@@ -53,6 +50,18 @@ export default async function(): Promise<void> {
 
   if (isWindows) {
     await ensureModdableCommandPrompt(spinner)
+  }
+
+  let createUnxz: any;
+  if (!isWindows) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+      // @ts-ignore
+      ({ createUnxz } = await import('node-liblzma'))
+    } catch (error) {
+      spinner.fail("Unable to extract Arm Embedded Toolchain without XZ utils (https://tukaani.org/xz/). Please install that dependency on your system and reinstall xs-dev before attempting this setup again. See https://xs-dev.js.org/troubleshooting for more info.")
+      process.exit(1)
+    }
   }
 
   spinner.info('Ensuring nrf52 directory')


### PR DESCRIPTION
For development environments that don't have xz utils available for the node-lzma native bindings, that dependency is now optional until attempting to setup the nrf52 tooling on Linux or MacOS. If node-lzma is not available, a helpful error message will be displayed.

I've also added a new "Troubleshooting" page that can be indexed to help folks find solutions to known issues. 

<img width="1410" alt="Screenshot 2023-08-18 at 4 43 33 PM" src="https://github.com/HipsterBrown/xs-dev/assets/3051193/45b84a0b-95d2-4e90-9647-c75c7fd66f7a">

---

In the future, it could be helpful to prompt xs-dev users to automatically install the XZ utils and attempt to install node-lzma after; rather than just display an error. I'm not sure how to do this without more experimentation, so this patch will suffice for the time being. 
