### PR TITLE
feat: add support for ESP-IDF v5 & mcpack

### DIFF
--- a/src/toolbox/build/index.ts
+++ b/src/toolbox/build/index.ts
@@ -245,8 +245,16 @@ export async function build({
     configArgs.push(`${element}="${value}"`)
   })
 
+  const canUseMCPack = system.which('mcpack') !== null && filesystem.exists(filesystem.resolve(projectPath, 'package.json')) === 'file'
+  let rootCommand = 'mcconfig'
+
+  if (canUseMCPack) {
+    rootCommand = 'mcpack'
+    configArgs.unshift('mcconfig')
+  }
+
   if (log) {
-    const logOutput = spawn('mcconfig', configArgs, { cwd: projectPath, stdio: 'inherit', shell: true });
+    const logOutput = spawn(rootCommand, configArgs, { cwd: projectPath, stdio: 'inherit', shell: true });
     logOutput.on('close', (exitCode) => {
       if (exitCode !== null) {
         process.exit(exitCode)
@@ -257,7 +265,7 @@ export async function build({
       void system.exec(`pkill serial2xsbug`)
     })
     try {
-      await system.exec(`mcconfig ${configArgs.join(' ')}`, {
+      await system.exec(`${rootCommand} ${configArgs.join(' ')}`, {
         cwd: projectPath,
         stdio: 'inherit',
         shell: true,

--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -1,7 +1,7 @@
-import { print, filesystem, system } from 'gluegun'
+import { print, filesystem, system, semver } from 'gluegun'
 import { type as platformType } from 'os'
 import { INSTALL_DIR, EXPORTS_FILE_PATH } from './constants'
-import { moddableExists } from './moddable'
+import { moddableExists, getModdableVersion } from './moddable'
 import upsert from '../patching/upsert'
 import { installDeps as installMacDeps } from './esp32/mac'
 import { installDeps as installLinuxDeps } from './esp32/linux'
@@ -13,7 +13,8 @@ export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
   const isWindows = OS === "windows_nt"
   const ESP_IDF_REPO = 'https://github.com/espressif/esp-idf.git'
-  const ESP_BRANCH = 'v4.4.3'
+  const ESP_BRANCH_v4 = 'v4.4.3'
+  const ESP_BRANCH_v5 = 'v5.1.1'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
 
@@ -41,8 +42,10 @@ export default async function(): Promise<void> {
   // 2. clone esp-idf into ~/.local/share/esp32/esp-idf
   if (filesystem.exists(IDF_PATH) === false) {
     spinner.start('Cloning esp-idf repo')
+    const moddableVersion = await getModdableVersion()
+    const branch = (moddableVersion?.includes("branch") || semver.satisfies(moddableVersion ?? '', '>= 4.2.x')) ? ESP_BRANCH_v5 : ESP_BRANCH_v4
     await system.spawn(
-      `git clone --depth 1 --single-branch -b ${ESP_BRANCH} --recursive ${ESP_IDF_REPO} ${IDF_PATH}`
+      `git clone --depth 1 --single-branch -b ${branch} --recursive ${ESP_IDF_REPO} ${IDF_PATH}`
     )
     spinner.succeed()
   }

--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -13,8 +13,8 @@ export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
   const isWindows = OS === "windows_nt"
   const ESP_IDF_REPO = 'https://github.com/espressif/esp-idf.git'
-  const ESP_BRANCH_v4 = 'v4.4.3'
-  const ESP_BRANCH_v5 = 'v5.1.1'
+  const ESP_BRANCH_V4 = 'v4.4.3'
+  const ESP_BRANCH_V5 = 'v5.1.1'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
 
@@ -42,8 +42,8 @@ export default async function(): Promise<void> {
   // 2. clone esp-idf into ~/.local/share/esp32/esp-idf
   if (filesystem.exists(IDF_PATH) === false) {
     spinner.start('Cloning esp-idf repo')
-    const moddableVersion = await getModdableVersion()
-    const branch = (moddableVersion?.includes("branch") || semver.satisfies(moddableVersion ?? '', '>= 4.2.x')) ? ESP_BRANCH_v5 : ESP_BRANCH_v4
+    const moddableVersion = await getModdableVersion() ?? ''
+    const branch = (moddableVersion.includes("branch") || semver.satisfies(moddableVersion ?? '', '>= 4.2.x')) ? ESP_BRANCH_V5 : ESP_BRANCH_V4
     await system.spawn(
       `git clone --depth 1 --single-branch -b ${branch} --recursive ${ESP_IDF_REPO} ${IDF_PATH}`
     )

--- a/src/toolbox/setup/moddable.ts
+++ b/src/toolbox/setup/moddable.ts
@@ -35,7 +35,8 @@ export function moddableExists(): boolean {
   return (
     process.env.MODDABLE !== undefined &&
     filesystem.exists(process.env.MODDABLE) === 'dir' &&
-    (releaseTools === 'dir' || debugTools === 'dir')
+    (releaseTools === 'dir' ||
+      debugTools === 'dir')
   )
 }
 

--- a/src/toolbox/update/esp32.ts
+++ b/src/toolbox/update/esp32.ts
@@ -9,8 +9,8 @@ import { sourceEnvironment } from '../system/exec'
 
 export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
-  const ESP_BRANCH_v4 = 'v4.4.3'
-  const ESP_BRANCH_v5 = 'v5.1.1'
+  const ESP_BRANCH_V4 = 'v4.4.3'
+  const ESP_BRANCH_V5 = 'v5.1.1'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
 
@@ -42,8 +42,8 @@ export default async function(): Promise<void> {
   // 2. update local esp-idf repo
   if (filesystem.exists(IDF_PATH) === 'dir') {
     spinner.start('Updating esp-idf repo')
-    const moddableVersion = await getModdableVersion()
-    const branch = (moddableVersion?.includes("branch") || semver.satisfies(moddableVersion ?? '', '>= 4.2.x')) ? ESP_BRANCH_v5 : ESP_BRANCH_v4
+    const moddableVersion = await getModdableVersion() ?? ''
+    const branch = (moddableVersion.includes("branch") || semver.satisfies(moddableVersion ?? '', '>= 4.2.x')) ? ESP_BRANCH_V5 : ESP_BRANCH_V4
     await system.spawn(`git fetch --all --tags`, { cwd: IDF_PATH })
     await system.spawn(`git checkout ${branch}`, { cwd: IDF_PATH })
     await system.spawn(`git submodule update --init --recursive`, {

--- a/src/toolbox/update/esp32.ts
+++ b/src/toolbox/update/esp32.ts
@@ -1,7 +1,7 @@
-import { print, filesystem, system, patching } from 'gluegun'
+import { print, filesystem, system, patching, semver } from 'gluegun'
 import { type as platformType } from 'os'
 import { INSTALL_DIR, EXPORTS_FILE_PATH } from '../setup/constants'
-import { moddableExists } from '../setup/moddable'
+import { getModdableVersion, moddableExists } from '../setup/moddable'
 import upsert from '../patching/upsert'
 import { installDeps as installMacDeps } from '../setup/esp32/mac'
 import { installDeps as installLinuxDeps } from '../setup/esp32/linux'
@@ -9,7 +9,8 @@ import { sourceEnvironment } from '../system/exec'
 
 export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
-  const ESP_BRANCH = 'v4.4.3'
+  const ESP_BRANCH_v4 = 'v4.4.3'
+  const ESP_BRANCH_v5 = 'v5.1.1'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
 
@@ -41,8 +42,10 @@ export default async function(): Promise<void> {
   // 2. update local esp-idf repo
   if (filesystem.exists(IDF_PATH) === 'dir') {
     spinner.start('Updating esp-idf repo')
+    const moddableVersion = await getModdableVersion()
+    const branch = (moddableVersion?.includes("branch") || semver.satisfies(moddableVersion ?? '', '>= 4.2.x')) ? ESP_BRANCH_v5 : ESP_BRANCH_v4
     await system.spawn(`git fetch --all --tags`, { cwd: IDF_PATH })
-    await system.spawn(`git checkout ${ESP_BRANCH}`, { cwd: IDF_PATH })
+    await system.spawn(`git checkout ${branch}`, { cwd: IDF_PATH })
     await system.spawn(`git submodule update --init --recursive`, {
       cwd: IDF_PATH,
     })


### PR DESCRIPTION
Following the release of [Moddable 4.2](https://github.com/Moddable-OpenSource/moddable/releases/tag/4.2.0), this PR adds support for updating to v5 of the ESP-IDF if the latest Moddable SDK is setup on the developer's system. 

Using `xs-dev update && xs-dev update --device esp32` will allow developers to get the latest and greatest without breaking a sweat. 

The release includes the new `mcpack` CLI to provide integration with third-party JS modules discovered through a `package.json` file, so xs-dev provides automatic usage of that utility when a `package.json` file is located within the current working directory during the `build` or `run` commands. As feedback comes in from the community, I hope to provide deeper support for third-party modules like scaffolding a publishable module with the `init` command. 