### PR TITLE
fix(setup/esp32): update a package name in linux.ts

### DIFF
--- a/src/toolbox/setup/esp32/linux.ts
+++ b/src/toolbox/setup/esp32/linux.ts
@@ -6,7 +6,7 @@ export async function installDeps(
   spinner: ReturnType<GluegunPrint['spin']>
 ): Promise<void> {
   await execWithSudo(
-    'apt-get install --yes git wget flex bison gperf python-is-python3 python3-pip python3-serial python-setuptools cmake ninja-build ccache libffi-dev libssl-dev dfu-util',
+    'apt-get install --yes git wget flex bison gperf python-is-python3 python3-pip python3-serial python3-setuptools cmake ninja-build ccache libffi-dev libssl-dev dfu-util',
     { stdout: process.stdout }
   )
   spinner.succeed()


### PR DESCRIPTION
Changed the package name from python-setuptools to python3-setuptools

Fixes #151 