### PR TITLE
fix(info): verify moddable sdk git repo, include nrf52 support

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -37,6 +37,15 @@ const command: GluegunCommand = {
     if (typeof process.env.PICO_SDK_PATH === 'string' && filesystem.exists(process.env.PICO_SDK_PATH) === 'dir' && system.which('picotool') !== null && filesystem.exists(process.env.PIOASM ?? '') === 'file') {
       supportedDevices.push('pico')
     }
+    if (typeof process.env.NRF_ROOT === 'string' &&
+      filesystem.exists(process.env.NRF_ROOT) === 'dir' &&
+      ((typeof process.env.NRF_SDK_DIR === 'string' &&
+        filesystem.exists(process.env.NRF_SDK_DIR) === 'dir') ||
+        (typeof process.env.NRF52_SDK_PATH === 'string' &&
+          filesystem.exists(process.env.NRF52_SDK_PATH) === 'dir'))
+    ) {
+      supportedDevices.push('nrf52')
+    }
 
     const pythonVersion = await getPythonVersion() ?? 'Unavailable'
     const pythonPath = system.which(detectPython() ?? '') ?? 'n/a'
@@ -58,6 +67,7 @@ const command: GluegunCommand = {
       supportedDevices.includes('esp8266') ? ['ESP8266 Base Directory', String(process.env.ESP_BASE)] : [],
       supportedDevices.includes('wasm') ? ['Wasm EMSDK Directory', String(process.env.ESMDK)] : [],
       supportedDevices.includes('pico') ? ['Pico SDK Directory', String(process.env.PICO_SDK_PATH)] : [],
+      supportedDevices.includes('nrf52') ? ['NRF52 SDK Directory', String(process.env.NRF_SDK_DIR ?? process.env.NRF52_SDK_PATH)] : [],
     ].filter(tuple => tuple.length !== 0))
 
     print.highlight(`\nIf this is related to an error when using the CLI, please create an issue at "https://github.com/hipsterbrown/xs-dev/issues/new" with the above info.`)

--- a/src/toolbox/setup/moddable.ts
+++ b/src/toolbox/setup/moddable.ts
@@ -40,8 +40,12 @@ export function moddableExists(): boolean {
   )
 }
 
+function isGitRepo(path: string): boolean {
+  return filesystem.exists(filesystem.resolve(path, '.git')) === 'dir';
+}
+
 export async function getModdableVersion(): Promise<string | null> {
-  if (moddableExists()) {
+  if (moddableExists() && isGitRepo(process.env.MODDABLE ?? '')) {
     const tags = await system.run('git tag -l --sort=-taggerdate', { cwd: process.env.MODDABLE })
     const tag = tags.split('\n').shift()
     const latestCommit = await system.run(`git rev-parse HEAD`, { cwd: process.env.MODDABLE })


### PR DESCRIPTION
Discovered by @mrpeu, the CLI assumes the directory for `process.env.MODDABLE` is a Git repository to be able to determine the Moddable SDK version or branch, as well as pull updates for the SDK. This PR adds an extra check to confirm it is a repo before attempting any git commands. 

While working in the `doctor` command module, I noticed support for `nrf52` was never added 😬 , so that has also been added in this PR. 