### PR TITLE
feat(update): use v5.3 tag of esp-idf

### DIFF
--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -14,7 +14,7 @@ export default async function(): Promise<void> {
   const isWindows = OS === "windows_nt"
   const ESP_IDF_REPO = 'https://github.com/espressif/esp-idf.git'
   const ESP_BRANCH_V4 = 'v4.4.3'
-  const ESP_BRANCH_V5 = 'v5.2.2'
+  const ESP_BRANCH_V5 = 'v5.3'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
 

--- a/src/toolbox/update/esp32.ts
+++ b/src/toolbox/update/esp32.ts
@@ -10,7 +10,7 @@ import { sourceEnvironment } from '../system/exec'
 export default async function(): Promise<void> {
   const OS = platformType().toLowerCase()
   const ESP_BRANCH_V4 = 'v4.4.3'
-  const ESP_BRANCH_V5 = 'v5.2.2'
+  const ESP_BRANCH_V5 = 'v5.3'
   const ESP32_DIR = filesystem.resolve(INSTALL_DIR, 'esp32')
   const IDF_PATH = filesystem.resolve(ESP32_DIR, 'esp-idf')
 


### PR DESCRIPTION
[Moddable SDK 4.9.5](https://github.com/Moddable-OpenSource/moddable/releases/tag/4.9.5) recommends using [ESP-IDF v5.3](https://github.com/espressif/esp-idf/releases). This PR update branch `ESP_BRANCH_V5`.
