### PR TITLE
fix(setup): remove xs-dev-export.sh sourcing from shell profile

### DIFF
--- a/docs/src/content/docs/features/setup.md
+++ b/docs/src/content/docs/features/setup.md
@@ -35,7 +35,7 @@ The [`moddable` git repo](https://github.com/Moddable-OpenSource/moddable) is cl
 
 **Environment config:**
 
-This command will create (and update) an environment configuration file called `~/.local/share/xs-dev-export.sh` (on Mac & Linux) or `Moddable.bat` (on Windows). This file will be placed in the shell setup file (`.profile`, `.zshrc`, `.bashrc`, etc on Mac & Linux) or the custom command prompt (on Windows), to set environment variables and call other "exports" files for embedded tooling.
+This command will create (and update) an environment configuration file called `~/.local/share/xs-dev-export.sh` (on Mac & Linux) or `Moddable.bat` (on Windows). This file will be sourced by `xs-dev` when running commands (on Mac & Linux) or through the custom command prompt (on Windows), to set environment variables and call other "exports" files for embedded tooling.
 
 ## Target Branch
 

--- a/src/toolbox/setup/esp32.ts
+++ b/src/toolbox/setup/esp32.ts
@@ -98,9 +98,6 @@ export default async function(): Promise<void> {
   // 6. append 'source $IDF_PATH/export.sh' to shell profile
   if (isWindows) {
     await upsert(EXPORTS_FILE_PATH, `pushd %IDF_PATH% && call "%IDF_TOOLS_PATH%\\idf_cmd_init.bat" && popd`)
-  } else {
-    spinner.info('Sourcing esp-idf environment')
-    await upsert(EXPORTS_FILE_PATH, `source $IDF_PATH/export.sh 1> /dev/null`)
   }
 
   spinner.succeed(`

--- a/src/toolbox/setup/linux.ts
+++ b/src/toolbox/setup/linux.ts
@@ -6,7 +6,6 @@ import {
   INSTALL_DIR,
   INSTALL_PATH,
   EXPORTS_FILE_PATH,
-  getProfilePath,
   XSBUG_LOG_PATH,
 } from './constants'
 import upsert from '../patching/upsert'
@@ -39,7 +38,6 @@ export default async function({ sourceRepo, targetBranch }: PlatformSetupArgs): 
     'makefiles',
     'lin'
   )
-  const PROFILE_PATH = getProfilePath()
 
   const spinner = print.spin()
   spinner.start('Beginning setup...')
@@ -110,8 +108,6 @@ export default async function({ sourceRepo, targetBranch }: PlatformSetupArgs): 
   // 4. Setup the MODDABLE environment variable
   process.env.MODDABLE = INSTALL_PATH
   process.env.PATH = `${String(process.env.PATH)}:${BIN_PATH}`
-
-  await upsert(PROFILE_PATH, `source ${EXPORTS_FILE_PATH}`)
 
   await upsert(EXPORTS_FILE_PATH, `export MODDABLE=${process.env.MODDABLE}`)
   await upsert(EXPORTS_FILE_PATH, `export PATH="${BIN_PATH}:$PATH"`)

--- a/src/toolbox/setup/mac.ts
+++ b/src/toolbox/setup/mac.ts
@@ -7,7 +7,6 @@ import {
   INSTALL_DIR,
   EXPORTS_FILE_PATH,
   XSBUG_LOG_PATH,
-  getProfilePath,
 } from './constants'
 import upsert from '../patching/upsert'
 import { downloadReleaseTools, fetchLatestRelease, MissingReleaseAssetError } from './moddable'
@@ -38,7 +37,6 @@ export default async function({ sourceRepo, targetBranch }: PlatformSetupArgs): 
     'makefiles',
     'mac'
   )
-  const PROFILE_PATH = getProfilePath()
 
   // 0. ensure xcode command line tools are available (?)
   try {
@@ -137,8 +135,6 @@ export default async function({ sourceRepo, targetBranch }: PlatformSetupArgs): 
   // 2. configure MODDABLE env variable, add release binaries dir to PATH
   process.env.MODDABLE = INSTALL_PATH
   process.env.PATH = `${String(process.env.PATH)}:${BIN_PATH}`
-
-  await upsert(PROFILE_PATH, `source ${EXPORTS_FILE_PATH}`)
 
   await upsert(EXPORTS_FILE_PATH, `export MODDABLE=${process.env.MODDABLE}`)
   await upsert(EXPORTS_FILE_PATH, `export PATH="${BIN_PATH}:$PATH"`)


### PR DESCRIPTION
Fixes #161 

Also, removes sourcing `$IDF_PATH/export.sh` automatically since the Moddable SDK takes care of it. 