### PR TITLE
fix(scan): source esp_idf before checking for esptool.py

### DIFF
--- a/src/toolbox/system/exec.ts
+++ b/src/toolbox/system/exec.ts
@@ -57,3 +57,24 @@ export async function sourceEnvironment(): Promise<void> {
     }
   }
 }
+
+/**
+ * Set updated env from user shell as process.env
+ */
+export async function sourceIdf(): Promise<void> {
+  const OS = platformType().toLowerCase() as Device
+
+  if (OS !== 'windows_nt') {
+    try {
+      const result = await system.spawn(`source $IDF_PATH/export.sh 1> /dev/null && env`, {
+        shell: process.env.SHELL,
+      })
+      if (typeof result.stdout === 'string' || result.stdout instanceof Buffer) {
+        const localEnv = Object.fromEntries(result.stdout.toString().split('\n').map((field: string) => field?.split('=')))
+        if ('PATH' in localEnv) process.env = localEnv
+      }
+    } catch (error) {
+      console.warn('Unable to source the ESP IDF settings:', error)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #98 

Also addresses introduced by #170 with the removal of `source $IDF_PATH/exports.sh` from the `xs-dev-exports.sh`. 