### PR TITLE
feat(pico): update SDK to v2.0.0

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -5,7 +5,7 @@ import type { Device } from '../types'
 import setupEjectfix from '../toolbox/setup/ejectfix'
 import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 import { MODDABLE_REPO } from '../toolbox/setup/constants'
-import type { SetupArgs, PlatformSetupArgs } from '../toolbox/setup/types'
+import type { SetupArgs } from '../toolbox/setup/types'
 
 interface SetupOptions {
   device?: Device
@@ -28,7 +28,7 @@ const command = buildCommand({
       targetBranch = 'latest-release',
       sourceRepo = MODDABLE_REPO,
     } = flags
-    let target: Device = device ?? currentPlatform
+    let target: Device = device ?? DEVICE_ALIAS[currentPlatform]
 
     if (device === undefined && listDevices) {
       const choices = [
@@ -72,8 +72,7 @@ const command = buildCommand({
       'lin',
       'linux',
     ]
-    const setup: (args: SetupArgs | PlatformSetupArgs) => Promise<void> =
-      await import(`../commands/setup.ts/${target}`)
+    const { default: setup } = await import(`../toolbox/setup/${target}`)
     if (platformDevices.includes(target)) {
       await setup({ targetBranch, sourceRepo })
     } else {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -15,8 +15,11 @@ const command = buildCommand({
   },
   async func(this: LocalContext, flags: UpdateOptions) {
     const currentPlatform: Device = platformType().toLowerCase() as Device
-    const { device = currentPlatform, targetBranch = 'latest-release' } = flags
-    const update = await import(`../toolbox/update/${device}`)
+    const {
+      device = DEVICE_ALIAS[currentPlatform],
+      targetBranch = 'latest-release',
+    } = flags
+    const { default: update } = await import(`../toolbox/update/${device}`)
     await update({ targetBranch })
   },
   parameters: {

--- a/src/toolbox/prompt/devices.ts
+++ b/src/toolbox/prompt/devices.ts
@@ -1,6 +1,6 @@
 import type { Device } from '../../types'
 
-export const DEVICE_ALIAS: Record<Device | 'esp8266', string> = Object.freeze({
+export const DEVICE_ALIAS: Record<Device | 'esp8266', Device> = Object.freeze({
   esp8266: 'esp',
   darwin: 'mac',
   mac: 'mac',

--- a/src/toolbox/setup/pico.ts
+++ b/src/toolbox/setup/pico.ts
@@ -9,7 +9,7 @@ import { sourceEnvironment } from '../system/exec'
 
 export default async function (): Promise<void> {
   const OS = platformType().toLowerCase()
-  const PICO_BRANCH = '1.5.0'
+  const PICO_BRANCH = '2.0.0'
   const PICO_SDK_REPO = 'https://github.com/raspberrypi/pico-sdk'
   const PICO_EXTRAS_REPO = 'https://github.com/raspberrypi/pico-extras'
   const PICO_EXAMPLES_REPO = 'https://github.com/raspberrypi/pico-examples'

--- a/src/toolbox/update/pico.ts
+++ b/src/toolbox/update/pico.ts
@@ -9,7 +9,7 @@ import { sourceEnvironment } from '../system/exec'
 
 export default async function (): Promise<void> {
   const OS = platformType().toLowerCase()
-  const PICO_BRANCH = '1.5.0'
+  const PICO_BRANCH = '2.0.0'
   const PICO_EXTRAS_REPO = 'https://github.com/raspberrypi/pico-extras'
   const PICO_ROOT =
     process.env.PICO_ROOT ?? filesystem.resolve(INSTALL_DIR, 'pico')


### PR DESCRIPTION
The Moddable SDK now depends on version 2.0.0 of the Raspberry Pi Pico SDK: https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/devices/pico.md#sdk-and-host-environment-setup

This PR updates the version used by the `setup` and `update` commands. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.32.8--canary.181.e4479a4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install xs-dev@0.32.8--canary.181.e4479a4.0
  # or 
  yarn add xs-dev@0.32.8--canary.181.e4479a4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
