### PR TITLE
fix(setup/pico): pin picotool repo branch, add pioasm build step

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -59,14 +59,14 @@ const command = buildCommand({
           const filteredChoices = choices.filter((choice) =>
             choice.includes(String(example)),
           )
-            ; ({ example: selectedExample } = await prompt.ask([
-              {
-                type: 'autocomplete',
-                name: 'example',
-                message: 'Here are the available examples templates:',
-                choices: filteredChoices.length > 0 ? filteredChoices : choices,
-              },
-            ]))
+          ;({ example: selectedExample } = await prompt.ask([
+            {
+              type: 'autocomplete',
+              name: 'example',
+              message: 'Here are the available examples templates:',
+              choices: filteredChoices.length > 0 ? filteredChoices : choices,
+            },
+          ]))
         }
 
         // copy files into new project directory
@@ -89,9 +89,9 @@ const command = buildCommand({
         const includes = [
           io
             ? [
-              '"$(MODDABLE)/modules/io/manifest.json"',
-              '"$(MODDABLE)/examples/manifest_net.json"',
-            ]
+                '"$(MODDABLE)/modules/io/manifest.json"',
+                '"$(MODDABLE)/examples/manifest_net.json"',
+              ]
             : '"$(MODDABLE)/examples/manifest_base.json"',
           typescript && '"$(MODDABLE)/examples/manifest_typings.json"',
         ]
@@ -103,7 +103,9 @@ const command = buildCommand({
           ? ',\n  defines: {\n    async_main: 1\n  }'
           : ''
 
-        const { createManifest, createMain } = await import('../toolbox/init/templates')
+        const { createManifest, createMain } = await import(
+          '../toolbox/init/templates'
+        )
 
         await Promise.all([
           createManifest({
@@ -113,7 +115,7 @@ const command = buildCommand({
           }),
           createMain({
             target: `${projectName}/main.${typescript ? 'ts' : 'js'}`,
-          })
+          }),
         ])
       }
 

--- a/src/toolbox/init/templates.ts
+++ b/src/toolbox/init/templates.ts
@@ -1,14 +1,18 @@
 import { writeFile } from 'node:fs/promises'
 
 export interface TemplateBuilderOptions {
-  target: string;
+  target: string
 }
 
 export interface CreateManifestOptions extends TemplateBuilderOptions {
-  includes: string;
-  defines: string;
+  includes: string
+  defines: string
 }
-export async function createManifest({ target, includes, defines }: CreateManifestOptions): Promise<void> {
+export async function createManifest({
+  target,
+  includes,
+  defines,
+}: CreateManifestOptions): Promise<void> {
   const template = `\
 {
   "include": [
@@ -22,7 +26,9 @@ export async function createManifest({ target, includes, defines }: CreateManife
   await writeFile(target, template, { encoding: 'utf8' })
 }
 
-export async function createMain({ target }: TemplateBuilderOptions): Promise<void> {
+export async function createMain({
+  target,
+}: TemplateBuilderOptions): Promise<void> {
   const template = `\
 debugger;
 

--- a/src/toolbox/setup/pico.ts
+++ b/src/toolbox/setup/pico.ts
@@ -22,14 +22,16 @@ export default async function (): Promise<void> {
   const PICOTOOL_PATH = filesystem.resolve(PICO_ROOT, 'picotool')
   const PICOTOOL_BUILD_DIR = filesystem.resolve(PICOTOOL_PATH, 'build')
   const PICO_SDK_BUILD_DIR = filesystem.resolve(PICO_SDK_DIR, 'build')
-  const PIOASM_PATH = filesystem.resolve(PICO_SDK_BUILD_DIR, 'pioasm', 'pioasm')
+  const PIOASM_TOOL_PATH = filesystem.resolve(PICO_SDK_DIR, 'tools', 'pioasm')
+  const PIOASM_BUILD_PATH = filesystem.resolve(PICO_SDK_BUILD_DIR, 'pioasm')
+  const PIOASM_PATH = filesystem.resolve(PIOASM_BUILD_PATH, 'pioasm')
 
   await sourceEnvironment()
 
   const spinner = print.spin()
   spinner.start('Starting pico tooling setup')
 
-  // 0. ensure pico instal directory and Moddable exists
+  // 0. ensure pico install directory and Moddable exists
   if (!moddableExists()) {
     spinner.fail(
       'Moddable platform tooling required. Run `xs-dev setup` before trying again.',
@@ -102,7 +104,7 @@ export default async function (): Promise<void> {
   if (filesystem.exists(PICOTOOL_PATH) === false) {
     spinner.start('Cloning picotool repo')
     await system.exec(
-      `git clone --depth 1 --single-branch -b master ${PICOTOOL_REPO} ${PICOTOOL_PATH}`,
+      `git clone --depth 1 --single-branch -b ${PICO_BRANCH} ${PICOTOOL_REPO} ${PICOTOOL_PATH}`,
       {
         stdout: process.stdout,
       },
@@ -146,6 +148,20 @@ export default async function (): Promise<void> {
       stdout: process.stdout,
       cwd: PICO_SDK_BUILD_DIR,
     })
+
+    // Build pioasm
+    filesystem.dir(PIOASM_BUILD_PATH)
+    await system.exec(`cmake ${PIOASM_TOOL_PATH}`, {
+      shell: process.env.SHELL,
+      stdout: process.stdout,
+      cwd: PIOASM_BUILD_PATH,
+    })
+    await system.exec('make', {
+      shell: process.env.SHELL,
+      stdout: process.stdout,
+      cwd: PIOASM_BUILD_PATH,
+    })
+
     spinner.succeed()
   }
 


### PR DESCRIPTION
While working on a project with the Raspberry Pi Pico (RP2040), I was unable to run any programs targeting the device after `xs-dev setup --device pico`. 

Part of this was due to the `picotool` CLI not building because xs-dev was cloning the `master` branch instead of the matching pico-sdk version (2.0.0 vs 2.1.0 which just released recently). 

Once that was resolved, the `pioasm` binary was unexpectedly missing but required by the Moddable SDK for the `pico` device target. As part of the major update from v1.5.1 to v2.0.0, the pico-sdk build stopped including `pioasm` by default, relying on developers to include that tool's CMake bootstrapping instructions in their CMakeLists.txt as needed. This was fixed in xs-dev by adding the cmake/make commands for pioasm after the default build for the pico-sdk. 

---

A potential fast follow: the `picoasm` and `picotool` binaries are now pre-built by Raspberry Pi for all supported platforms (Mac/Windows/Linux) and distributed from the https://github.com/raspberrypi/pico-sdk-tools repo. Some logic could be added to the Pico setup code to grab the appropriate zip/tar.gz file for pico-sdk-tools and picotool, respectively, instead of building them on the fly. This could be the first step towards Windows support for the pico with Moddable projects.  