### PR TITLE
fix(setup/pico): set PICO_EXAMPLES_DIR env var in exports file

### DIFF
--- a/src/toolbox/setup/pico.ts
+++ b/src/toolbox/setup/pico.ts
@@ -131,6 +131,19 @@ export default async function (): Promise<void> {
     )
   }
 
+  if (process.env.PICO_EXAMPLES_DIR === undefined) {
+    spinner.info('Setting PICO_EXAMPLES_DIR')
+    process.env.PICO_EXAMPLES_DIR = PICO_EXAMPLES_PATH
+    await upsert(
+      EXPORTS_FILE_PATH,
+      `export PICO_EXAMPLES_DIR=${PICO_EXAMPLES_PATH}`,
+    )
+  } else {
+    spinner.info(
+      `Using existing $PICO_EXAMPLES_DIR: ${process.env.PICO_EXAMPLES_DIR}`,
+    )
+  }
+
   // 4. Build some pico tools:
   if (
     filesystem.exists(PICO_SDK_BUILD_DIR) === false ||


### PR DESCRIPTION
To run a program targeting the pico with `mcpack` or `mcconfig` (depending on the included SDK modules), the PICO_EXAMPLES_DIR and PICO_EXTRAS_DIR environment variables need to be set (see https://github.com/Moddable-OpenSource/moddable/blob/public/build/devices/pico/manifest.json#L2-L5). The default expected paths don't match the conventions set by xs-dev, so they should be able to override in the `moddable.manifest` config in the package.json or in the `manifest.json` file. Until then the default manifest.json for the pico needs to be manually edited to remove the `build` variables settings. 

I will follow up in the Moddable SDK repo to resolve this going forward.  