### PR TITLE
fix: use kebab-case command flags, loosen device target typing for build/run commands

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -10,8 +10,8 @@ interface BuildOptions {
   device?: Device
   port?: string
   example?: string
-  listExamples?: boolean
-  listDevices?: boolean
+  'list-examples'?: boolean
+  'list-devices'?: boolean
   mode?: Mode
   output?: string
   deploy?: boolean
@@ -35,8 +35,8 @@ const command = buildCommand({
       device = currentPlatform,
       deploy = false,
       example,
-      listExamples = false,
-      listDevices = false,
+      'list-examples': listExamples = false,
+      'list-devices': listDevices = false,
       mode = (process.env.NODE_ENV as Mode) ?? 'development',
       output,
       port,
@@ -99,12 +99,12 @@ const command = buildCommand({
           'Name of example project to run, use --list-examples to select from an interactive list',
         optional: true,
       },
-      listExamples: {
+      'list-examples': {
         kind: 'boolean',
         brief: 'Select an example project from an interactive list',
         optional: true,
       },
-      listDevices: {
+      'list-devices': {
         kind: 'boolean',
         brief: 'Select a target device or platform from an interactive list',
         optional: true,

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -7,7 +7,7 @@ import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 type Mode = 'development' | 'production'
 
 interface BuildOptions {
-  device?: Device
+  device?: string
   port?: string
   example?: string
   'list-examples'?: boolean
@@ -42,7 +42,7 @@ const command = buildCommand({
       port,
       config = [],
     } = flags
-    const targetPlatform: string = DEVICE_ALIAS[device] ?? device
+    const targetPlatform: string = DEVICE_ALIAS[device as Device] ?? device
     projectPath = filesystem.resolve(projectPath)
     const parsedConfig = config.reduce<Record<string, string>>(
       (result, setting) => {
@@ -81,8 +81,8 @@ const command = buildCommand({
     },
     flags: {
       device: {
-        kind: 'enum',
-        values: Object.keys(DEVICE_ALIAS) as NonNullable<Device[]>,
+        kind: 'parsed',
+        parse: String,
         brief:
           'Target device or platform for the project, use --list-devices to select from interactive list; defaults to current OS simulator',
         optional: true,

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -7,7 +7,7 @@ import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 type Mode = 'development' | 'production'
 
 interface CleanOptions {
-  device?: Device
+  device?: string
   example?: string
   'list-examples'?: boolean
   'list-devices'?: boolean
@@ -38,7 +38,7 @@ const command = buildCommand({
       output,
       config = [],
     } = flags
-    const targetPlatform: string = DEVICE_ALIAS[device] ?? device
+    const targetPlatform: string = DEVICE_ALIAS[device as Device] ?? device
     projectPath = filesystem.resolve(projectPath)
     const parsedConfig = config.reduce<Record<string, string>>(
       (result, setting) => {
@@ -76,8 +76,8 @@ const command = buildCommand({
     },
     flags: {
       device: {
-        kind: 'enum',
-        values: Object.keys(DEVICE_ALIAS) as NonNullable<Device[]>,
+        kind: 'parsed',
+        parse: String,
         brief:
           'Target device or platform for the project, use --list-devices to select from interactive list; defaults to current OS simulator',
         optional: true,

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -9,8 +9,8 @@ type Mode = 'development' | 'production'
 interface CleanOptions {
   device?: Device
   example?: string
-  listExamples?: boolean
-  listDevices?: boolean
+  'list-examples'?: boolean
+  'list-devices'?: boolean
   mode?: Mode
   output?: string
   config?: string[]
@@ -32,8 +32,8 @@ const command = buildCommand({
     const {
       device = currentPlatform,
       example,
-      listExamples = false,
-      listDevices = false,
+      'list-examples': listExamples = false,
+      'list-devices': listDevices = false,
       mode = (process.env.NODE_ENV as Mode) ?? 'development',
       output,
       config = [],
@@ -89,12 +89,12 @@ const command = buildCommand({
           'Name of example project to run, use --list-examples to select from an interactive list',
         optional: true,
       },
-      listExamples: {
+      'list-examples': {
         kind: 'boolean',
         brief: 'Select an example project from an interactive list',
         optional: true,
       },
-      listDevices: {
+      'list-devices': {
         kind: 'boolean',
         brief: 'Select a target device or platform from an interactive list',
         optional: true,

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -7,7 +7,7 @@ import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 type Mode = 'development' | 'production'
 
 interface DebugOptions {
-  device?: Device
+  device?: string
   port?: string
   example?: string
   'list-examples'?: boolean
@@ -40,7 +40,7 @@ const command = buildCommand({
       output,
     } = flags
     const { build } = await import('../toolbox/build/index')
-    const targetPlatform: string = DEVICE_ALIAS[device] ?? device
+    const targetPlatform: string = DEVICE_ALIAS[device as Device] ?? device
     projectPath = filesystem.resolve(projectPath)
 
     await build({
@@ -71,8 +71,8 @@ const command = buildCommand({
     },
     flags: {
       device: {
-        kind: 'enum',
-        values: Object.keys(DEVICE_ALIAS) as NonNullable<Device[]>,
+        kind: 'parsed',
+        parse: String,
         brief:
           'Target device or platform for the project, use --list-devices to select from interactive list; defaults to current OS simulator',
         optional: true,

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -10,8 +10,8 @@ interface DebugOptions {
   device?: Device
   port?: string
   example?: string
-  listExamples?: boolean
-  listDevices?: boolean
+  'list-examples'?: boolean
+  'list-devices'?: boolean
   log?: boolean
   mode?: Mode
   output?: string
@@ -33,8 +33,8 @@ const command = buildCommand({
       device = currentPlatform,
       port,
       example,
-      listExamples = false,
-      listDevices = false,
+      'list-examples': listExamples = false,
+      'list-devices': listDevices = false,
       log = false,
       mode = (process.env.NODE_ENV as Mode) ?? 'development',
       output,
@@ -84,12 +84,12 @@ const command = buildCommand({
           'Name of example project to run, use --list-examples to select from an interactive list',
         optional: true,
       },
-      listExamples: {
+      'list-examples': {
         kind: 'boolean',
         brief: 'Select an example project from an interactive list',
         optional: true,
       },
-      listDevices: {
+      'list-devices': {
         kind: 'boolean',
         brief: 'Select a target device or platform from an interactive list',
         optional: true,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,7 +7,7 @@ interface InitOptions {
   typescript?: boolean
   io?: boolean
   example?: string
-  listExamples?: boolean
+  'list-examples'?: boolean
   overwrite?: boolean
   asyncMain?: boolean
 }
@@ -27,7 +27,7 @@ const command = buildCommand({
       typescript = false,
       io = false,
       example,
-      listExamples = false,
+      'list-examples': listExamples = false,
       overwrite = false,
       asyncMain = false,
     } = flags
@@ -59,14 +59,14 @@ const command = buildCommand({
           const filteredChoices = choices.filter((choice) =>
             choice.includes(String(example)),
           )
-          ;({ example: selectedExample } = await prompt.ask([
-            {
-              type: 'autocomplete',
-              name: 'example',
-              message: 'Here are the available examples templates:',
-              choices: filteredChoices.length > 0 ? filteredChoices : choices,
-            },
-          ]))
+            ; ({ example: selectedExample } = await prompt.ask([
+              {
+                type: 'autocomplete',
+                name: 'example',
+                message: 'Here are the available examples templates:',
+                choices: filteredChoices.length > 0 ? filteredChoices : choices,
+              },
+            ]))
         }
 
         // copy files into new project directory
@@ -89,9 +89,9 @@ const command = buildCommand({
         const includes = [
           io
             ? [
-                '"$(MODDABLE)/modules/io/manifest.json"',
-                '"$(MODDABLE)/examples/manifest_net.json"',
-              ]
+              '"$(MODDABLE)/modules/io/manifest.json"',
+              '"$(MODDABLE)/examples/manifest_net.json"',
+            ]
             : '"$(MODDABLE)/examples/manifest_base.json"',
           typescript && '"$(MODDABLE)/examples/manifest_typings.json"',
         ]
@@ -157,7 +157,7 @@ const command = buildCommand({
         parse: String,
         optional: true,
       },
-      listExamples: {
+      'list-examples': {
         kind: 'boolean',
         brief: 'Select an example project from the Moddable SDK',
         optional: true,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -59,14 +59,14 @@ const command = buildCommand({
           const filteredChoices = choices.filter((choice) =>
             choice.includes(String(example)),
           )
-            ; ({ example: selectedExample } = await prompt.ask([
-              {
-                type: 'autocomplete',
-                name: 'example',
-                message: 'Here are the available examples templates:',
-                choices: filteredChoices.length > 0 ? filteredChoices : choices,
-              },
-            ]))
+          ;({ example: selectedExample } = await prompt.ask([
+            {
+              type: 'autocomplete',
+              name: 'example',
+              message: 'Here are the available examples templates:',
+              choices: filteredChoices.length > 0 ? filteredChoices : choices,
+            },
+          ]))
         }
 
         // copy files into new project directory
@@ -89,9 +89,9 @@ const command = buildCommand({
         const includes = [
           io
             ? [
-              '"$(MODDABLE)/modules/io/manifest.json"',
-              '"$(MODDABLE)/examples/manifest_net.json"',
-            ]
+                '"$(MODDABLE)/modules/io/manifest.json"',
+                '"$(MODDABLE)/examples/manifest_net.json"',
+              ]
             : '"$(MODDABLE)/examples/manifest_base.json"',
           typescript && '"$(MODDABLE)/examples/manifest_typings.json"',
         ]

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -10,8 +10,8 @@ interface RunOptions {
   device?: Device
   port?: string
   example?: string
-  listExamples?: boolean
-  listDevices?: boolean
+  'list-examples'?: boolean
+  'list-devices'?: boolean
   log?: boolean
   mode?: Mode
   output?: string
@@ -30,8 +30,8 @@ const command = buildCommand({
     const {
       device = currentPlatform,
       example,
-      listExamples = false,
-      listDevices = false,
+      'list-examples': listExamples = false,
+      'list-devices': listDevices = false,
       log = false,
       mode = (process.env.NODE_ENV as Mode) ?? 'development',
       output,
@@ -91,12 +91,12 @@ const command = buildCommand({
           'Name of example project to run, use --list-examples to select from an interactive list',
         optional: true,
       },
-      listExamples: {
+      'list-examples': {
         kind: 'boolean',
         brief: 'Select an example project from an interactive list',
         optional: true,
       },
-      listDevices: {
+      'list-devices': {
         kind: 'boolean',
         brief: 'Select a target device or platform from an interactive list',
         optional: true,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,7 +7,7 @@ import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 type Mode = 'development' | 'production'
 
 interface RunOptions {
-  device?: Device
+  device?: string
   port?: string
   example?: string
   'list-examples'?: boolean
@@ -38,7 +38,7 @@ const command = buildCommand({
       port,
       config = [],
     } = flags
-    const targetPlatform: string = DEVICE_ALIAS[device] ?? device
+    const targetPlatform: string = DEVICE_ALIAS[device as Device] ?? device
     projectPath = filesystem.resolve(projectPath)
     const parsedConfig = config.reduce<Record<string, string>>(
       (result, setting) => {
@@ -78,8 +78,8 @@ const command = buildCommand({
     },
     flags: {
       device: {
-        kind: 'enum',
-        values: Object.keys(DEVICE_ALIAS) as NonNullable<Device[]>,
+        kind: 'parsed',
+        parse: String,
         brief:
           'Target device or platform for the project, use --list-devices to select from interactive list; defaults to current OS simulator',
         optional: true,

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -9,10 +9,10 @@ import type { SetupArgs } from '../toolbox/setup/types'
 
 interface SetupOptions {
   device?: Device
-  listDevices?: boolean
+  'list-devices'?: boolean
   tool?: 'ejectfix'
-  targetBranch?: SetupArgs['targetBranch']
-  sourceRepo?: string
+  'target-branch'?: SetupArgs['targetBranch']
+  'source-repo'?: string
 }
 const command = buildCommand({
   docs: {
@@ -23,10 +23,10 @@ const command = buildCommand({
     const currentPlatform: Device = platformType().toLowerCase() as Device
     const {
       device,
-      listDevices = false,
+      'list-devices': listDevices = false,
       tool,
-      targetBranch = 'latest-release',
-      sourceRepo = MODDABLE_REPO,
+      'target-branch': targetBranch = 'latest-release',
+      'source-repo': sourceRepo = MODDABLE_REPO,
     } = flags
     let target: Device = device ?? DEVICE_ALIAS[currentPlatform]
 
@@ -88,7 +88,7 @@ const command = buildCommand({
           'Target device or platform SDK to set up; defaults to Moddable SDK for current OS; use --list-devices for interactive selection',
         optional: true,
       },
-      listDevices: {
+      'list-devices': {
         kind: 'boolean',
         brief:
           'Select target device or platform SDK to set up from a list; defaults to false',
@@ -100,14 +100,14 @@ const command = buildCommand({
         brief: 'Install additional tooling to support common development tasks',
         optional: true,
       },
-      targetBranch: {
+      'target-branch': {
         kind: 'parsed',
         parse: String,
         brief:
           'The remote branch or release to use as source for Moddable SDK set up; defaults to `latest-release`',
         optional: true,
       },
-      sourceRepo: {
+      'source-repo': {
         kind: 'parsed',
         parse: String,
         brief:

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -6,7 +6,7 @@ import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 
 interface UpdateOptions {
   device?: Device
-  targetBranch?: 'public' | 'latest-release'
+  'target-branch'?: 'public' | 'latest-release'
 }
 
 const command = buildCommand({
@@ -17,7 +17,7 @@ const command = buildCommand({
     const currentPlatform: Device = platformType().toLowerCase() as Device
     const {
       device = DEVICE_ALIAS[currentPlatform],
-      targetBranch = 'latest-release',
+      'target-branch': targetBranch = 'latest-release',
     } = flags
     const { default: update } = await import(`../toolbox/update/${device}`)
     await update({ targetBranch })
@@ -31,7 +31,7 @@ const command = buildCommand({
           'Target device or platform SDK to set up; defaults to Moddable SDK for current OS',
         optional: true,
       },
-      targetBranch: {
+      'target-branch': {
         kind: 'enum',
         values: ['public', 'latest-release'],
         brief:


### PR DESCRIPTION
Discovered a few regressions from the refactor to use Strcli while building a few projects with xs-dev recently:

- the multi-word command flags, such as `--list-examples` or `target-branch`, were accidentally changed to camelCase from the original kebab-case
- the `--device` flag for the `build` / `run` / `clean` / `debug` commands was made an enum to match the `setup` command, however it should accept the "sub-target" device specifiers, i.e. `esp32/s3`, as well

Both of these are resolved in this PR. I opted for making the `--device` flag just a string argument instead of expanding the enum of values to reduce complexity of trying to fetch all the available options before building the command object and exploding the generated help text. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.33.5--canary.196.7f057a9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install xs-dev@0.33.5--canary.196.7f057a9.0
  # or 
  yarn add xs-dev@0.33.5--canary.196.7f057a9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
