### PR TITLE
feat(setup/update): split target-branch into release, branch options

### DIFF
--- a/docs/src/content/docs/features/setup.md
+++ b/docs/src/content/docs/features/setup.md
@@ -37,20 +37,38 @@ The [`moddable` git repo](https://github.com/Moddable-OpenSource/moddable) is cl
 
 This command will create (and update) an environment configuration file called `~/.local/share/xs-dev-export.sh` (on Mac & Linux) or `Moddable.bat` (on Windows). This file will be sourced by `xs-dev` when running commands (on Mac & Linux) or through the custom command prompt (on Windows), to set environment variables and call other "exports" files for embedded tooling.
 
+## Tagged Release
+
+The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 
+
+To override this behavior, use the `--release` flag to select a tagged release version; this fetches the pre-compiled release assets and latest commit off that tag.
+
+```
+xs-dev setup --release 5.3.0
+```
+
+When combined with the `--source-repo` flag, it's possible to get the SDK from another source instead of the default GitHub repo.
+
+```
+xs-dev setup --source-repo https://my-sdk.moddable-git.not-real --release 5.4.0-alpha
+```
+
+_This will only work for the `mac`, `windows`, and `linux` device options, which are the respective defaults for the operating system on which the command is run._
+
 ## Target Branch
 
 The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 
 
-To override this behavior, use the `--target-branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools. This can be set to any branch name, however `public` is the main public branch for the Moddable-OpenSource repo.
+To override this behavior, use the `--branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools. This can be set to any branch name, however `public` is the main public branch for the Moddable-OpenSource repo.
 
 ```
-xs-dev setup --target-branch public
+xs-dev setup --branch public
 ```
 
 When combined with the `--source-repo` flag, it's possible to get the SDK repo from another source instead of the default GitHub repo.
 
 ```
-xs-dev setup --source-repo https://my-sdk.moddable-git.not-real --target-branch main
+xs-dev setup --source-repo https://my-sdk.moddable-git.not-real --branch main
 ```
 
 _This will only work for the `mac`, `windows`, and `linux` device options, which are the respective defaults for the operating system on which the command is run._

--- a/docs/src/content/docs/features/update.md
+++ b/docs/src/content/docs/features/update.md
@@ -11,14 +11,26 @@ Stay up to date with the latest tooling from Moddable and supported device targe
 xs-dev update
 ```
 
+## Tagged Release
+
+The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 
+
+To override this behavior, use the `--release` flag to select a tagged release version; this fetches the pre-compiled release assets and latest commit off that tag.
+
+```
+xs-dev update --release 5.3.0
+```
+
+_This will only work for the `mac`, `windows`, and `linux` device options, which are the respective defaults for the operating system on which the command is run._
+
 ## Target Branch
 
 The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 
 
-To override this behavior, use the `--target-branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools.
+To override this behavior, use the `--branch` flag to select `public`; this fetches the latest commit off that main branch and runs the build to generate the associated tools.
 
 ```
-xs-dev setup --target-branch public
+xs-dev update --branch public
 ```
 
 _This will only work for the `mac`, `windows`, and `linux` device options, which are the respective defaults for the operating system on which the command is run._

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -59,14 +59,14 @@ const command = buildCommand({
           const filteredChoices = choices.filter((choice) =>
             choice.includes(String(example)),
           )
-            ; ({ example: selectedExample } = await prompt.ask([
-              {
-                type: 'autocomplete',
-                name: 'example',
-                message: 'Here are the available examples templates:',
-                choices: filteredChoices.length > 0 ? filteredChoices : choices,
-              },
-            ]))
+          ;({ example: selectedExample } = await prompt.ask([
+            {
+              type: 'autocomplete',
+              name: 'example',
+              message: 'Here are the available examples templates:',
+              choices: filteredChoices.length > 0 ? filteredChoices : choices,
+            },
+          ]))
         }
 
         // copy files into new project directory
@@ -89,9 +89,9 @@ const command = buildCommand({
         const includes = [
           io
             ? [
-              '"$(MODDABLE)/modules/io/manifest.json"',
-              '"$(MODDABLE)/examples/manifest_net.json"',
-            ]
+                '"$(MODDABLE)/modules/io/manifest.json"',
+                '"$(MODDABLE)/examples/manifest_net.json"',
+              ]
             : '"$(MODDABLE)/examples/manifest_base.json"',
           typescript && '"$(MODDABLE)/examples/manifest_typings.json"',
         ]

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -42,7 +42,7 @@ const command = buildCommand({
 
       await sourceEnvironment()
 
-      if (example !== undefined ?? listExamples) {
+      if (example !== undefined || listExamples) {
         // find example project
         const exampleProjectPath = filesystem.resolve(
           String(process.env.MODDABLE),
@@ -59,14 +59,14 @@ const command = buildCommand({
           const filteredChoices = choices.filter((choice) =>
             choice.includes(String(example)),
           )
-          ;({ example: selectedExample } = await prompt.ask([
-            {
-              type: 'autocomplete',
-              name: 'example',
-              message: 'Here are the available examples templates:',
-              choices: filteredChoices.length > 0 ? filteredChoices : choices,
-            },
-          ]))
+            ; ({ example: selectedExample } = await prompt.ask([
+              {
+                type: 'autocomplete',
+                name: 'example',
+                message: 'Here are the available examples templates:',
+                choices: filteredChoices.length > 0 ? filteredChoices : choices,
+              },
+            ]))
         }
 
         // copy files into new project directory
@@ -89,9 +89,9 @@ const command = buildCommand({
         const includes = [
           io
             ? [
-                '"$(MODDABLE)/modules/io/manifest.json"',
-                '"$(MODDABLE)/examples/manifest_net.json"',
-              ]
+              '"$(MODDABLE)/modules/io/manifest.json"',
+              '"$(MODDABLE)/examples/manifest_net.json"',
+            ]
             : '"$(MODDABLE)/examples/manifest_base.json"',
           typescript && '"$(MODDABLE)/examples/manifest_typings.json"',
         ]

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -11,7 +11,8 @@ interface SetupOptions {
   device?: Device
   'list-devices'?: boolean
   tool?: 'ejectfix'
-  'target-branch'?: SetupArgs['targetBranch']
+  branch?: SetupArgs['branch']
+  release?: SetupArgs['release']
   'source-repo'?: string
 }
 const command = buildCommand({
@@ -25,7 +26,8 @@ const command = buildCommand({
       device,
       'list-devices': listDevices = false,
       tool,
-      'target-branch': targetBranch = 'latest-release',
+      branch,
+      release = 'latest',
       'source-repo': sourceRepo = MODDABLE_REPO,
     } = flags
     let target: Device = device ?? DEVICE_ALIAS[currentPlatform]
@@ -74,9 +76,9 @@ const command = buildCommand({
     ]
     const { default: setup } = await import(`../toolbox/setup/${target}`)
     if (platformDevices.includes(target)) {
-      await setup({ targetBranch, sourceRepo })
+      await setup({ branch, release, sourceRepo })
     } else {
-      await setup({ targetBranch })
+      await setup({ branch, release })
     }
   },
   parameters: {
@@ -100,11 +102,18 @@ const command = buildCommand({
         brief: 'Install additional tooling to support common development tasks',
         optional: true,
       },
-      'target-branch': {
+      branch: {
         kind: 'parsed',
         parse: String,
         brief:
-          'The remote branch or release to use as source for Moddable SDK set up; defaults to `latest-release`',
+          'The remote branch to use as the source for Moddable SDK set up',
+        optional: true,
+      },
+      release: {
+        kind: 'parsed',
+        parse: String,
+        brief:
+          'The release tag to use as the source for Moddable SDK set up; defaults to `latest`',
         optional: true,
       },
       'source-repo': {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -105,8 +105,7 @@ const command = buildCommand({
       branch: {
         kind: 'parsed',
         parse: String,
-        brief:
-          'The remote branch to use as the source for Moddable SDK set up',
+        brief: 'The remote branch to use as the source for Moddable SDK set up',
         optional: true,
       },
       release: {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -6,7 +6,8 @@ import { DEVICE_ALIAS } from '../toolbox/prompt/devices'
 
 interface UpdateOptions {
   device?: Device
-  'target-branch'?: 'public' | 'latest-release'
+  branch?: 'public' | string
+  release?: 'latest' | string
 }
 
 const command = buildCommand({
@@ -17,10 +18,11 @@ const command = buildCommand({
     const currentPlatform: Device = platformType().toLowerCase() as Device
     const {
       device = DEVICE_ALIAS[currentPlatform],
-      'target-branch': targetBranch = 'latest-release',
+      branch,
+      release = 'latest',
     } = flags
     const { default: update } = await import(`../toolbox/update/${device}`)
-    await update({ targetBranch })
+    await update({ branch, release })
   },
   parameters: {
     flags: {
@@ -31,11 +33,18 @@ const command = buildCommand({
           'Target device or platform SDK to set up; defaults to Moddable SDK for current OS',
         optional: true,
       },
-      'target-branch': {
-        kind: 'enum',
-        values: ['public', 'latest-release'],
+      branch: {
+        kind: 'parsed',
+        parse: String,
         brief:
-          'The remote branch or release to use as source for Moddable SDK update; defaults to `latest-release`',
+          'The remote branch to use as source for Moddable SDK update; overrides the --release flag',
+        optional: true,
+      },
+      release: {
+        kind: 'parsed',
+        parse: String,
+        brief:
+          'The tagged release to use as source for Moddable SDK update; defaults to `latest`',
         optional: true,
       },
     },

--- a/src/toolbox/prompt/choices.ts
+++ b/src/toolbox/prompt/choices.ts
@@ -11,7 +11,7 @@ export function collectChoicesFromTree(
 ): string[] {
   if (
     fd.type === 'dir' &&
-    fd.children.find((file) => file.name === 'manifest.json') !== undefined
+    fd.children.find((file) => ['manifest.json', 'package.json'].includes(file.name)) !== undefined
   ) {
     results.push(root + fd.name)
   } else if (fd.type === 'dir') {

--- a/src/toolbox/prompt/choices.ts
+++ b/src/toolbox/prompt/choices.ts
@@ -11,7 +11,9 @@ export function collectChoicesFromTree(
 ): string[] {
   if (
     fd.type === 'dir' &&
-    fd.children.find((file) => ['manifest.json', 'package.json'].includes(file.name)) !== undefined
+    fd.children.find((file) =>
+      ['manifest.json', 'package.json'].includes(file.name),
+    ) !== undefined
   ) {
     results.push(root + fd.name)
   } else if (fd.type === 'dir') {

--- a/src/toolbox/setup/linux.ts
+++ b/src/toolbox/setup/linux.ts
@@ -15,7 +15,7 @@ import { fetchRelease, downloadReleaseTools } from './moddable'
 
 const chmodPromise = promisify(chmod)
 
-export default async function({
+export default async function ({
   sourceRepo,
   branch,
   release,
@@ -70,7 +70,7 @@ export default async function({
   if (filesystem.exists(INSTALL_PATH) !== false) {
     spinner.info('Moddable repo already installed')
   } else {
-    if (release && (branch === undefined || branch === null)) {
+    if (release !== undefined && (branch === undefined || branch === null)) {
       spinner.start('Getting latest Moddable-OpenSource/moddable release')
       const remoteRelease = await fetchRelease(release)
       await system.spawn(
@@ -117,7 +117,7 @@ export default async function({
   await upsert(EXPORTS_FILE_PATH, `export PATH="${BIN_PATH}:$PATH"`)
 
   // 5. Build the Moddable command line tools, simulator, and debugger from the command line:
-  if (branch) {
+  if (typeof branch === 'string') {
     spinner.start('Building platform tooling')
     await system.exec('make', { cwd: BUILD_DIR, stdout: process.stdout })
     spinner.succeed()
@@ -125,7 +125,7 @@ export default async function({
 
   // 6. Install the desktop simulator and xsbug debugger applications
   spinner.start('Installing simulator')
-  if (release && (branch === undefined || branch === null)) {
+  if (release !== undefined && (branch === undefined || branch === null)) {
     filesystem.dir(
       filesystem.resolve(
         BUILD_DIR,

--- a/src/toolbox/setup/linux.ts
+++ b/src/toolbox/setup/linux.ts
@@ -11,13 +11,14 @@ import {
 import upsert from '../patching/upsert'
 import { execWithSudo } from '../system/exec'
 import type { PlatformSetupArgs } from './types'
-import { fetchLatestRelease, downloadReleaseTools } from './moddable'
+import { fetchRelease, downloadReleaseTools } from './moddable'
 
 const chmodPromise = promisify(chmod)
 
-export default async function ({
+export default async function({
   sourceRepo,
-  targetBranch,
+  branch,
+  release,
 }: PlatformSetupArgs): Promise<void> {
   print.info('Setting up Linux tools!')
 
@@ -69,11 +70,11 @@ export default async function ({
   if (filesystem.exists(INSTALL_PATH) !== false) {
     spinner.info('Moddable repo already installed')
   } else {
-    if (targetBranch === 'latest-release') {
+    if (release && (branch === undefined || branch === null)) {
       spinner.start('Getting latest Moddable-OpenSource/moddable release')
-      const release = await fetchLatestRelease()
+      const remoteRelease = await fetchRelease(release)
       await system.spawn(
-        `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${release.tag_name} --single-branch`,
+        `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${remoteRelease.tag_name} --single-branch`,
       )
 
       filesystem.dir(BIN_PATH)
@@ -87,7 +88,7 @@ export default async function ({
       await downloadReleaseTools({
         writePath: BIN_PATH,
         assetName,
-        release,
+        release: remoteRelease,
       })
       const tools = filesystem.list(BIN_PATH) ?? []
       await Promise.all(
@@ -102,7 +103,7 @@ export default async function ({
     } else {
       spinner.start(`Cloning ${sourceRepo} repo`)
       await system.spawn(
-        `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${targetBranch} --single-branch`,
+        `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${branch} --single-branch`,
       )
     }
     spinner.succeed()
@@ -116,7 +117,7 @@ export default async function ({
   await upsert(EXPORTS_FILE_PATH, `export PATH="${BIN_PATH}:$PATH"`)
 
   // 5. Build the Moddable command line tools, simulator, and debugger from the command line:
-  if (targetBranch !== 'latest-release') {
+  if (branch) {
     spinner.start('Building platform tooling')
     await system.exec('make', { cwd: BUILD_DIR, stdout: process.stdout })
     spinner.succeed()
@@ -124,7 +125,7 @@ export default async function ({
 
   // 6. Install the desktop simulator and xsbug debugger applications
   spinner.start('Installing simulator')
-  if (targetBranch === 'latest-release') {
+  if (release && (branch === undefined || branch === null)) {
     filesystem.dir(
       filesystem.resolve(
         BUILD_DIR,

--- a/src/toolbox/setup/mac.ts
+++ b/src/toolbox/setup/mac.ts
@@ -18,7 +18,7 @@ import type { PlatformSetupArgs } from './types'
 
 const chmodPromise = promisify(chmod)
 
-export default async function({
+export default async function ({
   sourceRepo,
   branch,
   release,
@@ -73,7 +73,7 @@ export default async function({
     spinner.info('Moddable repo already installed')
   } else {
     try {
-      if (release && (branch === undefined || branch === null)) {
+      if (release !== undefined && (branch === undefined || branch === null)) {
         spinner.start('Getting latest Moddable-OpenSource/moddable release')
         const remoteRelease = await fetchRelease(release)
         await system.spawn(

--- a/src/toolbox/setup/mac.ts
+++ b/src/toolbox/setup/mac.ts
@@ -11,16 +11,17 @@ import {
 import upsert from '../patching/upsert'
 import {
   downloadReleaseTools,
-  fetchLatestRelease,
+  fetchRelease,
   MissingReleaseAssetError,
 } from './moddable'
 import type { PlatformSetupArgs } from './types'
 
 const chmodPromise = promisify(chmod)
 
-export default async function ({
+export default async function({
   sourceRepo,
-  targetBranch,
+  branch,
+  release,
 }: PlatformSetupArgs): Promise<void> {
   print.info('Setting up the mac tools!')
 
@@ -72,11 +73,11 @@ export default async function ({
     spinner.info('Moddable repo already installed')
   } else {
     try {
-      if (targetBranch === 'latest-release') {
+      if (release && (branch === undefined || branch === null)) {
         spinner.start('Getting latest Moddable-OpenSource/moddable release')
-        const release = await fetchLatestRelease()
+        const remoteRelease = await fetchRelease(release)
         await system.spawn(
-          `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${release.tag_name} --single-branch`,
+          `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${remoteRelease.tag_name} --single-branch`,
         )
 
         filesystem.dir(BIN_PATH)
@@ -88,7 +89,7 @@ export default async function ({
           await downloadReleaseTools({
             writePath: BIN_PATH,
             assetName: universalAssetName,
-            release,
+            release: remoteRelease,
           })
         } catch (error: unknown) {
           if (error instanceof MissingReleaseAssetError) {
@@ -99,7 +100,7 @@ export default async function ({
             await downloadReleaseTools({
               writePath: BIN_PATH,
               assetName,
-              release,
+              release: remoteRelease,
             })
           } else {
             throw error as Error
@@ -129,7 +130,7 @@ export default async function ({
       } else {
         spinner.start(`Cloning ${sourceRepo} repo`)
         await system.spawn(
-          `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${targetBranch} --single-branch`,
+          `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${branch} --single-branch`,
         )
       }
       spinner.succeed()
@@ -147,7 +148,7 @@ export default async function ({
   await upsert(EXPORTS_FILE_PATH, `export PATH="${BIN_PATH}:$PATH"`)
 
   // 3. cd into makefiles dir for platform, run `make`
-  if (targetBranch !== 'latest-release') {
+  if (branch !== undefined || branch !== null) {
     try {
       spinner.start('Building platform tooling')
       await system.exec('make', { cwd: BUILD_DIR, stdout: process.stdout })

--- a/src/toolbox/setup/moddable.ts
+++ b/src/toolbox/setup/moddable.ts
@@ -62,7 +62,9 @@ type GitHubRelease = ExtractFromArray<
   RestEndpointMethodTypes['repos']['listReleases']['response']['data']
 >
 
-export async function fetchRelease(release: 'latest' | string): Promise<GitHubRelease> {
+export async function fetchRelease(
+  release: 'latest' | string,
+): Promise<GitHubRelease> {
   const octokit = new Octokit()
   if (release === 'latest') {
     const { data: latestRelease } = await octokit.rest.repos.getLatestRelease({
@@ -74,7 +76,7 @@ export async function fetchRelease(release: 'latest' | string): Promise<GitHubRe
     const { data: taggedRelease } = await octokit.rest.repos.getReleaseByTag({
       owner: 'Moddable-OpenSource',
       repo: 'moddable',
-      tag: release
+      tag: release,
     })
     return taggedRelease
   }

--- a/src/toolbox/setup/moddable.ts
+++ b/src/toolbox/setup/moddable.ts
@@ -62,18 +62,27 @@ type GitHubRelease = ExtractFromArray<
   RestEndpointMethodTypes['repos']['listReleases']['response']['data']
 >
 
-export async function fetchLatestRelease(): Promise<GitHubRelease> {
+export async function fetchRelease(release: 'latest' | string): Promise<GitHubRelease> {
   const octokit = new Octokit()
-  const { data: latestRelease } = await octokit.rest.repos.getLatestRelease({
-    owner: 'Moddable-OpenSource',
-    repo: 'moddable',
-  })
-  return latestRelease
+  if (release === 'latest') {
+    const { data: latestRelease } = await octokit.rest.repos.getLatestRelease({
+      owner: 'Moddable-OpenSource',
+      repo: 'moddable',
+    })
+    return latestRelease
+  } else {
+    const { data: taggedRelease } = await octokit.rest.repos.getReleaseByTag({
+      owner: 'Moddable-OpenSource',
+      repo: 'moddable',
+      tag: release
+    })
+    return taggedRelease
+  }
 }
 
 export class MissingReleaseAssetError extends Error {
   constructor(assetName: string) {
-    super(`Unabled to find release asset matching ${assetName}`)
+    super(`Unable to find release asset matching ${assetName}`)
   }
 }
 

--- a/src/toolbox/setup/types.ts
+++ b/src/toolbox/setup/types.ts
@@ -1,5 +1,6 @@
 export interface SetupArgs {
-  targetBranch: 'public' | 'latest-release' | string
+  branch: 'public' | string
+  release: 'latest' | string
 }
 
 export interface PlatformSetupArgs extends SetupArgs {

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -9,7 +9,7 @@ import upsert from '../patching/upsert'
 import ws from 'windows-shortcuts'
 import { promisify } from 'util'
 import type { PlatformSetupArgs } from './types'
-import { downloadReleaseTools, fetchLatestRelease } from './moddable'
+import { downloadReleaseTools, fetchRelease } from './moddable'
 
 const wsPromise = promisify(ws.create)
 
@@ -55,9 +55,10 @@ export async function ensureModdableCommandPrompt(
   }
 }
 
-export default async function ({
+export default async function({
   sourceRepo,
-  targetBranch,
+  branch,
+  release,
 }: PlatformSetupArgs): Promise<void> {
   const BIN_PATH = filesystem.resolve(
     INSTALL_PATH,
@@ -216,11 +217,11 @@ export default async function ({
     spinner.info('Moddable repo already installed')
   } else {
     try {
-      if (targetBranch === 'latest-release') {
+      if (release && (branch === undefined || branch === null)) {
         spinner.start(`Getting latest Moddable-OpenSource/moddable release`)
-        const release = await fetchLatestRelease()
+        const remoteRelease = await fetchRelease(release)
         await system.spawn(
-          `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${release.tag_name} --single-branch`,
+          `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${remoteRelease.tag_name} --single-branch`,
         )
 
         filesystem.dir(BIN_PATH)
@@ -232,7 +233,7 @@ export default async function ({
         await downloadReleaseTools({
           writePath: BIN_PATH,
           assetName,
-          release,
+          release: remoteRelease,
         })
 
         const tools = filesystem.list(BIN_PATH) ?? []
@@ -249,7 +250,7 @@ export default async function ({
       } else {
         spinner.start(`Cloning ${sourceRepo} repo`)
         await system.spawn(
-          `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${targetBranch} --single-branch`,
+          `git clone ${sourceRepo} ${INSTALL_PATH} --depth 1 --branch ${branch} --single-branch`,
         )
       }
     } catch (error) {
@@ -270,7 +271,7 @@ export default async function ({
   }
 
   // 3. build tools if needed
-  if (targetBranch !== 'latest-release') {
+  if (branch) {
     try {
       spinner.start(`Building Moddable SDK tools`)
       await system.exec(`build.bat`, { cwd: BUILD_DIR, stdout: process.stdout })

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -55,7 +55,7 @@ export async function ensureModdableCommandPrompt(
   }
 }
 
-export default async function({
+export default async function ({
   sourceRepo,
   branch,
   release,
@@ -217,7 +217,7 @@ export default async function({
     spinner.info('Moddable repo already installed')
   } else {
     try {
-      if (release && (branch === undefined || branch === null)) {
+      if (release !== undefined && (branch === undefined || branch === null)) {
         spinner.start(`Getting latest Moddable-OpenSource/moddable release`)
         const remoteRelease = await fetchRelease(release)
         await system.spawn(
@@ -271,7 +271,7 @@ export default async function({
   }
 
   // 3. build tools if needed
-  if (branch) {
+  if (typeof branch === 'string') {
     try {
       spinner.start(`Building Moddable SDK tools`)
       await system.exec(`build.bat`, { cwd: BUILD_DIR, stdout: process.stdout })

--- a/src/toolbox/update/linux.ts
+++ b/src/toolbox/update/linux.ts
@@ -5,7 +5,7 @@ import { print, system, filesystem } from 'gluegun'
 import { INSTALL_PATH, MODDABLE_REPO, XSBUG_LOG_PATH } from '../setup/constants'
 import type { SetupArgs } from '../setup/types'
 import {
-  fetchLatestRelease,
+  fetchRelease,
   moddableExists,
   downloadReleaseTools,
 } from '../setup/moddable'
@@ -13,7 +13,7 @@ import { execWithSudo, sourceEnvironment } from '../system/exec'
 
 const chmodPromise = promisify(chmod)
 
-export default async function ({ targetBranch }: SetupArgs): Promise<void> {
+export default async function({ branch, release }: SetupArgs): Promise<void> {
   await sourceEnvironment()
 
   // 0. ensure Moddable exists
@@ -33,15 +33,15 @@ export default async function ({ targetBranch }: SetupArgs): Promise<void> {
     'lin',
   )
 
-  if (targetBranch === 'latest-release') {
+  if (release && (branch === undefined || branch === null)) {
     // get tag for current repo
     const currentTag: string = await system.exec('git tag', {
       cwd: process.env.MODDABLE,
     })
     // get latest release tag
-    const latestRelease = await fetchLatestRelease()
+    const remoteRelease = await fetchRelease(release)
 
-    if (currentTag.trim() === latestRelease.tag_name) {
+    if (currentTag.trim() === remoteRelease.tag_name) {
       print.success('Moddable SDK already up to date!')
       process.exit(0)
     }
@@ -66,7 +66,7 @@ export default async function ({ targetBranch }: SetupArgs): Promise<void> {
 
     filesystem.remove(process.env.MODDABLE)
     await system.spawn(
-      `git clone ${MODDABLE_REPO} ${INSTALL_PATH} --depth 1 --branch ${latestRelease.tag_name} --single-branch`,
+      `git clone ${MODDABLE_REPO} ${INSTALL_PATH} --depth 1 --branch ${remoteRelease.tag_name} --single-branch`,
     )
 
     filesystem.dir(BIN_PATH)
@@ -81,7 +81,7 @@ export default async function ({ targetBranch }: SetupArgs): Promise<void> {
     await downloadReleaseTools({
       writePath: BIN_PATH,
       assetName,
-      release: latestRelease,
+      release: remoteRelease,
     })
 
     spinner.info('Updating tool permissions')
@@ -140,12 +140,12 @@ export default async function ({ targetBranch }: SetupArgs): Promise<void> {
     )
   }
 
-  if (targetBranch === 'public') {
-    const currentRev: string = await system.exec('git rev-parse public', {
+  if (branch) {
+    const currentRev: string = await system.exec(`git rev-parse ${branch}`, {
       cwd: process.env.MODDABLE,
     })
     const remoteRev: string = await system.exec(
-      'git ls-remote origin refs/heads/public',
+      `git ls-remote origin refs/heads/${branch}`,
       { cwd: process.env.MODDABLE },
     )
 
@@ -159,7 +159,7 @@ export default async function ({ targetBranch }: SetupArgs): Promise<void> {
 
     spinner.start('Stashing any unsaved changes before committing')
     await system.exec('git stash', { cwd: process.env.MODDABLE })
-    await system.exec('git pull origin public', { cwd: process.env.MODDABLE })
+    await system.exec(`git pull origin ${branch}`, { cwd: process.env.MODDABLE })
 
     await system.exec('rm -rf build/{tmp,bin}', { cwd: process.env.MODDABLE })
     spinner.succeed()

--- a/src/toolbox/update/linux.ts
+++ b/src/toolbox/update/linux.ts
@@ -13,7 +13,7 @@ import { execWithSudo, sourceEnvironment } from '../system/exec'
 
 const chmodPromise = promisify(chmod)
 
-export default async function({ branch, release }: SetupArgs): Promise<void> {
+export default async function ({ branch, release }: SetupArgs): Promise<void> {
   await sourceEnvironment()
 
   // 0. ensure Moddable exists
@@ -33,7 +33,7 @@ export default async function({ branch, release }: SetupArgs): Promise<void> {
     'lin',
   )
 
-  if (release && (branch === undefined || branch === null)) {
+  if (release !== undefined && (branch === undefined || branch === null)) {
     // get tag for current repo
     const currentTag: string = await system.exec('git tag', {
       cwd: process.env.MODDABLE,
@@ -140,7 +140,7 @@ export default async function({ branch, release }: SetupArgs): Promise<void> {
     )
   }
 
-  if (branch) {
+  if (typeof branch === 'string') {
     const currentRev: string = await system.exec(`git rev-parse ${branch}`, {
       cwd: process.env.MODDABLE,
     })
@@ -159,7 +159,9 @@ export default async function({ branch, release }: SetupArgs): Promise<void> {
 
     spinner.start('Stashing any unsaved changes before committing')
     await system.exec('git stash', { cwd: process.env.MODDABLE })
-    await system.exec(`git pull origin ${branch}`, { cwd: process.env.MODDABLE })
+    await system.exec(`git pull origin ${branch}`, {
+      cwd: process.env.MODDABLE,
+    })
 
     await system.exec('rm -rf build/{tmp,bin}', { cwd: process.env.MODDABLE })
     spinner.succeed()

--- a/src/toolbox/update/mac.ts
+++ b/src/toolbox/update/mac.ts
@@ -14,7 +14,7 @@ import { sourceEnvironment } from '../system/exec'
 
 const chmodPromise = promisify(chmod)
 
-export default async function({ branch, release }: SetupArgs): Promise<void> {
+export default async function ({ branch, release }: SetupArgs): Promise<void> {
   print.info('Checking for SDK changes')
 
   await sourceEnvironment()
@@ -27,7 +27,7 @@ export default async function({ branch, release }: SetupArgs): Promise<void> {
     process.exit(1)
   }
 
-  if (release && (branch === undefined || branch === null)) {
+  if (release !== undefined && (branch === undefined || branch === null)) {
     // get tag for current repo
     const currentTag: string = await system.exec('git tag', {
       cwd: process.env.MODDABLE,
@@ -121,7 +121,7 @@ export default async function({ branch, release }: SetupArgs): Promise<void> {
     )
   }
 
-  if (branch) {
+  if (typeof branch === 'string') {
     const currentRev: string = await system.exec(`git rev-parse ${branch}`, {
       cwd: process.env.MODDABLE,
     })
@@ -140,7 +140,9 @@ export default async function({ branch, release }: SetupArgs): Promise<void> {
 
     spinner.start('Stashing any unsaved changes before committing')
     await system.exec('git stash', { cwd: process.env.MODDABLE })
-    await system.exec(`git pull origin ${branch}`, { cwd: process.env.MODDABLE })
+    await system.exec(`git pull origin ${branch}`, {
+      cwd: process.env.MODDABLE,
+    })
 
     const BUILD_DIR = filesystem.resolve(
       process.env.MODDABLE ?? '',


### PR DESCRIPTION
When attempting to update to the [latest Moddable SDK release](https://github.com/Moddable-OpenSource/moddable/releases/tag/5.3.3), I ran into missing release assets after pulling the tagged branch and resulting in a broken setup. To fix this and make the `setup` and `update` commands more flexible for versioned release installs, I updated those commands to split the `--target-branch` flag into `--release` and `--branch`: the former providing tagged release support and the latter providing support for any remote branch name. 