### PR TITLE
fix(setup,update):  build SDK tools if not included in tagged release

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -31,16 +31,18 @@ const command = buildCommand({
       )
     }
 
-    spinner.start('Scanning for devices...')
-
     const hasPicotool = system.which('picotool') !== null
 
     if (hasPicotool) {
       try {
+        spinner.start('Found picotool, rebooting device before scanning')
         await system.exec('picotool reboot -fa')
         await sleep(1000)
+        spinner.stop()
       } catch {}
     }
+
+    spinner.start('Scanning for devices...')
 
     const ports = await SerialPort.list()
     const result: Array<
@@ -50,10 +52,7 @@ const command = buildCommand({
         .filter((port) => port.serialNumber !== undefined)
         .map(async (port) => {
           try {
-            if (
-              port.manufacturer?.includes('Raspberry Pi') === true &&
-              hasPicotool
-            ) {
+            if (port.vendorId === '2e8a' && hasPicotool) {
               const device = await findBySerialNumber(port.serialNumber ?? '')
               const bus = String(device?.busNumber)
               const address = String(device?.deviceAddress)

--- a/src/toolbox/update/mac.ts
+++ b/src/toolbox/update/mac.ts
@@ -1,7 +1,7 @@
 import os from 'os'
 import { promisify } from 'util'
 import { chmod } from 'fs'
-import { print, system, filesystem } from 'gluegun'
+import { print, system, filesystem, prompt } from 'gluegun'
 import { INSTALL_PATH, MODDABLE_REPO, XSBUG_LOG_PATH } from '../setup/constants'
 import {
   fetchRelease,
@@ -27,6 +27,8 @@ export default async function ({ branch, release }: SetupArgs): Promise<void> {
     process.exit(1)
   }
 
+  let rebuildTools = false
+
   if (release !== undefined && (branch === undefined || branch === null)) {
     // get tag for current repo
     const currentTag: string = await system.exec('git tag', {
@@ -40,85 +42,104 @@ export default async function ({ branch, release }: SetupArgs): Promise<void> {
       process.exit(0)
     }
 
+    if (remoteRelease.assets.length === 0) {
+      print.warning(
+        `Moddable release ${release} does not have any pre-built assets.`,
+      )
+      rebuildTools = await prompt.confirm(
+        'Would you like to continue updating and build the SDK locally?',
+        false,
+      )
+
+      if (!rebuildTools) {
+        print.info(
+          'Please select another release version with pre-built assets: https://github.com/Moddable-OpenSource/moddable/releases',
+        )
+        process.exit(0)
+      }
+    }
+
     const spinner = print.spin()
     spinner.start('Updating Moddable SDK!')
-
-    const BIN_PATH = filesystem.resolve(
-      INSTALL_PATH,
-      'build',
-      'bin',
-      'mac',
-      'release',
-    )
-    const DEBUG_BIN_PATH = filesystem.resolve(
-      INSTALL_PATH,
-      'build',
-      'bin',
-      'mac',
-      'debug',
-    )
 
     filesystem.remove(process.env.MODDABLE)
     await system.spawn(
       `git clone ${MODDABLE_REPO} ${INSTALL_PATH} --depth 1 --branch ${remoteRelease.tag_name} --single-branch`,
     )
 
-    filesystem.dir(BIN_PATH)
-    filesystem.dir(DEBUG_BIN_PATH)
+    if (!rebuildTools) {
+      const BIN_PATH = filesystem.resolve(
+        INSTALL_PATH,
+        'build',
+        'bin',
+        'mac',
+        'release',
+      )
+      const DEBUG_BIN_PATH = filesystem.resolve(
+        INSTALL_PATH,
+        'build',
+        'bin',
+        'mac',
+        'debug',
+      )
 
-    try {
-      const universalAssetName = `moddable-tools-macuniversal.zip`
-      await downloadReleaseTools({
-        writePath: BIN_PATH,
-        assetName: universalAssetName,
-        release: remoteRelease,
-      })
-    } catch (error: unknown) {
-      if (error instanceof MissingReleaseAssetError) {
-        const isArm = os.arch() === 'arm64'
-        const assetName = isArm
-          ? 'moddable-tools-mac64arm.zip'
-          : 'moddable-tools-mac64.zip'
+      filesystem.dir(BIN_PATH)
+      filesystem.dir(DEBUG_BIN_PATH)
+
+      try {
+        const universalAssetName = `moddable-tools-macuniversal.zip`
         await downloadReleaseTools({
           writePath: BIN_PATH,
-          assetName,
+          assetName: universalAssetName,
           release: remoteRelease,
         })
-      } else {
-        throw error as Error
-      }
-    }
-
-    spinner.info('Updating tool permissions')
-    const tools = filesystem.list(BIN_PATH) ?? []
-    await Promise.all(
-      tools.map(async (tool) => {
-        if (tool.endsWith('.app')) {
-          const mainPath = filesystem.resolve(
-            BIN_PATH,
-            tool,
-            'Contents',
-            'MacOS',
-            'main',
-          )
-          await chmodPromise(mainPath, 0o751)
+      } catch (error: unknown) {
+        if (error instanceof MissingReleaseAssetError) {
+          const isArm = os.arch() === 'arm64'
+          const assetName = isArm
+            ? 'moddable-tools-mac64arm.zip'
+            : 'moddable-tools-mac64.zip'
+          await downloadReleaseTools({
+            writePath: BIN_PATH,
+            assetName,
+            release: remoteRelease,
+          })
         } else {
-          await chmodPromise(filesystem.resolve(BIN_PATH, tool), 0o751)
+          throw error as Error
         }
-        await filesystem.copyAsync(
-          filesystem.resolve(BIN_PATH, tool),
-          filesystem.resolve(DEBUG_BIN_PATH, tool),
-        )
-      }),
-    )
-    if (system.which('npm') !== null) {
-      spinner.start('Installing xsbug-log dependencies')
-      await system.exec('npm install', { cwd: XSBUG_LOG_PATH })
-      spinner.succeed()
+      }
+
+      spinner.info('Updating tool permissions')
+      const tools = filesystem.list(BIN_PATH) ?? []
+      await Promise.all(
+        tools.map(async (tool) => {
+          if (tool.endsWith('.app')) {
+            const mainPath = filesystem.resolve(
+              BIN_PATH,
+              tool,
+              'Contents',
+              'MacOS',
+              'main',
+            )
+            await chmodPromise(mainPath, 0o751)
+          } else {
+            await chmodPromise(filesystem.resolve(BIN_PATH, tool), 0o751)
+          }
+          await filesystem.copyAsync(
+            filesystem.resolve(BIN_PATH, tool),
+            filesystem.resolve(DEBUG_BIN_PATH, tool),
+          )
+        }),
+      )
+      if (system.which('npm') !== null) {
+        spinner.start('Installing xsbug-log dependencies')
+        await system.exec('npm install', { cwd: XSBUG_LOG_PATH })
+        spinner.succeed()
+      }
+      spinner.succeed(
+        'Moddable SDK successfully updated! Start the xsbug.app and run the "helloworld example": xs-dev run --example helloworld',
+      )
     }
-    spinner.succeed(
-      'Moddable SDK successfully updated! Start the xsbug.app and run the "helloworld example": xs-dev run --example helloworld',
-    )
   }
 
   if (typeof branch === 'string') {
@@ -135,6 +156,8 @@ export default async function ({ branch, release }: SetupArgs): Promise<void> {
       process.exit(0)
     }
 
+    rebuildTools = true
+
     const spinner = print.spin()
     spinner.start('Updating Moddable SDK!')
 
@@ -143,7 +166,10 @@ export default async function ({ branch, release }: SetupArgs): Promise<void> {
     await system.exec(`git pull origin ${branch}`, {
       cwd: process.env.MODDABLE,
     })
-
+    spinner.succeed()
+  }
+  if (rebuildTools) {
+    const spinner = print.spin()
     const BUILD_DIR = filesystem.resolve(
       process.env.MODDABLE ?? '',
       'build',
@@ -156,7 +182,6 @@ export default async function ({ branch, release }: SetupArgs): Promise<void> {
     )
     filesystem.remove(BUILD_DIR)
     filesystem.remove(TMP_DIR)
-    spinner.succeed()
 
     spinner.start('Rebuilding platform tools')
     // install release assets or build

--- a/src/toolbox/update/pico.ts
+++ b/src/toolbox/update/pico.ts
@@ -10,7 +10,6 @@ import { sourceEnvironment } from '../system/exec'
 export default async function (): Promise<void> {
   const OS = platformType().toLowerCase()
   const PICO_BRANCH = '2.0.0'
-  const PICO_EXTRAS_REPO = 'https://github.com/raspberrypi/pico-extras'
   const PICO_ROOT =
     process.env.PICO_ROOT ?? filesystem.resolve(INSTALL_DIR, 'pico')
   const PICO_SDK_DIR = filesystem.resolve(PICO_ROOT, 'pico-sdk')
@@ -25,7 +24,7 @@ export default async function (): Promise<void> {
   const spinner = print.spin()
   spinner.start('Starting pico tooling update')
 
-  // 0. ensure pico instal directory and Moddable exists
+  // 0. ensure pico install directory and Moddable exists
   if (!moddableExists()) {
     spinner.fail(
       'Moddable platform tooling required. Run `xs-dev setup` before trying again.',
@@ -85,10 +84,6 @@ export default async function (): Promise<void> {
 
   if (filesystem.exists(PICO_EXTRAS_DIR) === 'dir') {
     spinner.start('Updating pico-extras repo')
-    await system.exec(
-      `git clone --depth 1 --single-branch -b sdk-${PICO_BRANCH} ${PICO_EXTRAS_REPO} ${PICO_EXTRAS_DIR}`,
-      { stdout: process.stdout },
-    )
     await system.spawn(`git fetch --all --tags`, { cwd: PICO_EXTRAS_DIR })
     await system.spawn(`git checkout sdk-${PICO_BRANCH}`, {
       cwd: PICO_EXTRAS_DIR,


### PR DESCRIPTION
After adding support for installing & updating the Moddable SDK from a specific tagged release version in #197, I was still running into the need for building the tooling (mcconfig, mcpack, simulator, etc) when not included in the release assets. This PR adds support for that workflow after confirming with the user. 

Also included is a fix for updating the pico support by removing the unnecessary `git clone` of the `pico-extras` repo before fetching tags and pulling the required SDK branch. 