### PR TITLE
fixed: stop spinner before prompt

### DIFF
--- a/src/toolbox/setup/linux.ts
+++ b/src/toolbox/setup/linux.ts
@@ -76,6 +76,7 @@ export default async function ({
       const remoteRelease = await fetchRelease(release)
 
       if (remoteRelease.assets.length === 0) {
+        spinner.stop()
         print.warning(
           `Moddable release ${release} does not have any pre-built assets.`,
         )
@@ -90,6 +91,7 @@ export default async function ({
           )
           process.exit(0)
         }
+        spinner.start()
       }
 
       await system.spawn(

--- a/src/toolbox/setup/mac.ts
+++ b/src/toolbox/setup/mac.ts
@@ -80,6 +80,7 @@ export default async function ({
         const remoteRelease = await fetchRelease(release)
 
         if (remoteRelease.assets.length === 0) {
+          spinner.stop()
           print.warning(
             `Moddable release ${release} does not have any pre-built assets.`,
           )
@@ -94,6 +95,7 @@ export default async function ({
             )
             process.exit(0)
           }
+          spinner.start()
         }
 
         await system.spawn(

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -223,6 +223,7 @@ export default async function ({
         const remoteRelease = await fetchRelease(release)
 
         if (remoteRelease.assets.length === 0) {
+          spinner.stop()
           print.warning(
             `Moddable release ${release} does not have any pre-built assets.`,
           )
@@ -237,6 +238,7 @@ export default async function ({
             )
             process.exit(0)
           }
+          spinner.start()
         }
 
         await system.spawn(


### PR DESCRIPTION
Moddable SDK 5.3.3 is released without pre-built binaries. "xs-dev setup" requires the prompt, but it doesn't work in spinner working.  https://github.com/HipsterBrown/xs-dev/pull/200

Reproduced on mac and linux.
This change fixes the prompt issue.
https://github.com/HipsterBrown/xs-dev/issues/201