### PR TITLE
feat(setup/update): add interactive mode

### DIFF
--- a/docs/src/content/docs/features/setup.md
+++ b/docs/src/content/docs/features/setup.md
@@ -37,6 +37,12 @@ The [`moddable` git repo](https://github.com/Moddable-OpenSource/moddable) is cl
 
 This command will create (and update) an environment configuration file called `~/.local/share/xs-dev-export.sh` (on Mac & Linux) or `Moddable.bat` (on Windows). This file will be sourced by `xs-dev` when running commands (on Mac & Linux) or through the custom command prompt (on Windows), to set environment variables and call other "exports" files for embedded tooling.
 
+## Interactive Input
+
+By default, this command may prompt during the setup process. To override this behavior, use the `--noInteractive` flag.
+
+If there is a environment variable called `CI` set to `true`, then this command will be non-interactive and automatically accept all prompts.
+
 ## Tagged Release
 
 The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 

--- a/docs/src/content/docs/features/update.md
+++ b/docs/src/content/docs/features/update.md
@@ -11,6 +11,12 @@ Stay up to date with the latest tooling from Moddable and supported device targe
 xs-dev update
 ```
 
+## Interactive Input
+
+By default, this command may prompt during the update process. To override this behavior, use the `--noInteractive` flag.
+
+If there is a environment variable called `CI` set to `true`, then this command will be non-interactive and automatically accept all prompts.
+
 ## Tagged Release
 
 The default behavior of this command for Moddable developer tooling pulls the [latest release tooling](https://github.com/Moddable-OpenSource/moddable/releases) and source code for the associated tagged branch. This provides a known-working state for the SDK and avoids needing to build the tooling on the local machine. 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -14,6 +14,7 @@ interface SetupOptions {
   branch?: SetupArgs['branch']
   release?: SetupArgs['release']
   'source-repo'?: string
+  interactive?: boolean
 }
 const command = buildCommand({
   docs: {
@@ -29,6 +30,7 @@ const command = buildCommand({
       branch,
       release = 'latest',
       'source-repo': sourceRepo = MODDABLE_REPO,
+      interactive = true,
     } = flags
     let target: Device =
       DEVICE_ALIAS[device ?? ('' as Device)] ?? DEVICE_ALIAS[currentPlatform]
@@ -78,7 +80,12 @@ const command = buildCommand({
     ]
     const { default: setup } = await import(`../toolbox/setup/${target}`)
     if (platformDevices.includes(target)) {
-      await setup({ branch, release, sourceRepo })
+      await setup({
+        branch,
+        release,
+        sourceRepo,
+        interactive: Boolean(process.env.CI) || interactive,
+      })
     } else {
       await setup({ branch, release })
     }
@@ -122,6 +129,12 @@ const command = buildCommand({
         parse: String,
         brief:
           'URL for remote repository to use as source for Moddable SDK set up; defaults to upstream project',
+        optional: true,
+      },
+      interactive: {
+        kind: 'boolean',
+        brief:
+          'Choose whether to show any prompts or automatically accept them; defaults to true unless CI environment variable is true.',
         optional: true,
       },
     },

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -8,6 +8,7 @@ interface UpdateOptions {
   device?: Device
   branch?: 'public' | string
   release?: 'latest' | string
+  interactive?: boolean
 }
 
 const command = buildCommand({
@@ -16,11 +17,20 @@ const command = buildCommand({
   },
   async func(this: LocalContext, flags: UpdateOptions) {
     const currentPlatform: Device = platformType().toLowerCase() as Device
-    const { device = currentPlatform, branch, release = 'latest' } = flags
+    const {
+      device = currentPlatform,
+      branch,
+      release = 'latest',
+      interactive = true,
+    } = flags
     const { default: update } = await import(
       `../toolbox/update/${DEVICE_ALIAS[device]}`
     )
-    await update({ branch, release })
+    await update({
+      branch,
+      release,
+      interactive: Boolean(process.env.CI) || interactive,
+    })
   },
   parameters: {
     flags: {
@@ -43,6 +53,12 @@ const command = buildCommand({
         parse: String,
         brief:
           'The tagged release to use as source for Moddable SDK update; defaults to `latest`',
+        optional: true,
+      },
+      interactive: {
+        kind: 'boolean',
+        brief:
+          'Choose whether to show any prompts or automatically accept them; defaults to true unless CI environment variable is true.',
         optional: true,
       },
     },

--- a/src/toolbox/setup/linux.ts
+++ b/src/toolbox/setup/linux.ts
@@ -19,6 +19,7 @@ export default async function ({
   sourceRepo,
   branch,
   release,
+  interactive,
 }: PlatformSetupArgs): Promise<void> {
   print.info('Setting up Linux tools!')
 
@@ -80,10 +81,12 @@ export default async function ({
         print.warning(
           `Moddable release ${release} does not have any pre-built assets.`,
         )
-        buildTools = await prompt.confirm(
-          'Would you like to continue setting up and build the SDK locally?',
-          true,
-        )
+        buildTools =
+          !interactive ||
+          (await prompt.confirm(
+            'Would you like to continue setting up and build the SDK locally?',
+            true,
+          ))
 
         if (!buildTools) {
           print.info(

--- a/src/toolbox/setup/mac.ts
+++ b/src/toolbox/setup/mac.ts
@@ -22,6 +22,7 @@ export default async function ({
   sourceRepo,
   branch,
   release,
+  interactive,
 }: PlatformSetupArgs): Promise<void> {
   print.info('Setting up the mac tools!')
 
@@ -84,10 +85,12 @@ export default async function ({
           print.warning(
             `Moddable release ${release} does not have any pre-built assets.`,
           )
-          buildTools = await prompt.confirm(
-            'Would you like to continue setting up and build the SDK locally?',
-            true,
-          )
+          buildTools =
+            !interactive ||
+            (await prompt.confirm(
+              'Would you like to continue setting up and build the SDK locally?',
+              true,
+            ))
 
           if (!buildTools) {
             print.info(

--- a/src/toolbox/setup/moddable.ts
+++ b/src/toolbox/setup/moddable.ts
@@ -13,7 +13,7 @@ const finishedPromise = promisify(finished)
 
 export function moddableExists(): boolean {
   const OS = platformType().toLowerCase() as Device
-  const platformDir = DEVICE_ALIAS[OS].substr(0,3)
+  const platformDir = DEVICE_ALIAS[OS].substr(0, 3)
   const releaseTools = filesystem.exists(
     filesystem.resolve(INSTALL_PATH, 'build', 'bin', platformDir, 'release'),
   )

--- a/src/toolbox/setup/types.ts
+++ b/src/toolbox/setup/types.ts
@@ -1,6 +1,7 @@
 export interface SetupArgs {
   branch: 'public' | string
   release: 'latest' | string
+  interactive: boolean
 }
 
 export interface PlatformSetupArgs extends SetupArgs {

--- a/src/toolbox/setup/windows.ts
+++ b/src/toolbox/setup/windows.ts
@@ -59,6 +59,7 @@ export default async function ({
   sourceRepo,
   branch,
   release,
+  interactive,
 }: PlatformSetupArgs): Promise<void> {
   const BIN_PATH = filesystem.resolve(
     INSTALL_PATH,
@@ -227,10 +228,12 @@ export default async function ({
           print.warning(
             `Moddable release ${release} does not have any pre-built assets.`,
           )
-          buildTools = await prompt.confirm(
-            'Would you like to continue setting up and build the SDK locally?',
-            true,
-          )
+          buildTools =
+            !interactive ||
+            (await prompt.confirm(
+              'Would you like to continue setting up and build the SDK locally?',
+              true,
+            ))
 
           if (!buildTools) {
             print.info(

--- a/src/toolbox/update/linux.ts
+++ b/src/toolbox/update/linux.ts
@@ -13,7 +13,11 @@ import { execWithSudo, sourceEnvironment } from '../system/exec'
 
 const chmodPromise = promisify(chmod)
 
-export default async function ({ branch, release }: SetupArgs): Promise<void> {
+export default async function ({
+  branch,
+  release,
+  interactive,
+}: SetupArgs): Promise<void> {
   await sourceEnvironment()
 
   // 0. ensure Moddable exists
@@ -51,10 +55,12 @@ export default async function ({ branch, release }: SetupArgs): Promise<void> {
       print.warning(
         `Moddable release ${release} does not have any pre-built assets.`,
       )
-      rebuildTools = await prompt.confirm(
-        'Would you like to continue updating and build the SDK locally?',
-        false,
-      )
+      rebuildTools =
+        !interactive ||
+        (await prompt.confirm(
+          'Would you like to continue updating and build the SDK locally?',
+          false,
+        ))
 
       if (!rebuildTools) {
         print.info(

--- a/src/toolbox/update/mac.ts
+++ b/src/toolbox/update/mac.ts
@@ -14,7 +14,11 @@ import { sourceEnvironment } from '../system/exec'
 
 const chmodPromise = promisify(chmod)
 
-export default async function ({ branch, release }: SetupArgs): Promise<void> {
+export default async function ({
+  branch,
+  release,
+  interactive,
+}: SetupArgs): Promise<void> {
   print.info('Checking for SDK changes')
 
   await sourceEnvironment()
@@ -46,10 +50,12 @@ export default async function ({ branch, release }: SetupArgs): Promise<void> {
       print.warning(
         `Moddable release ${release} does not have any pre-built assets.`,
       )
-      rebuildTools = await prompt.confirm(
-        'Would you like to continue updating and build the SDK locally?',
-        false,
-      )
+      rebuildTools =
+        !interactive ||
+        (await prompt.confirm(
+          'Would you like to continue updating and build the SDK locally?',
+          false,
+        ))
 
       if (!rebuildTools) {
         print.info(


### PR DESCRIPTION
Fixes #204 

Preview of new help text:

```console
USAGE
  xs-dev setup [--device esp|esp8266|darwin|mac|windows_nt|windows|win|linux|lin|esp32|wasm|pico|nrf52] [--list-devices] [--tool ejectfix] [--branch value] [--release value] [--source-repo value] [--interactive]
  xs-dev setup --help

Download and build Moddable tooling for various platform targets

FLAGS
     [--device]                         Target device or platform SDK to set up; defaults to Moddable SDK for current OS; use --list-devices for interactive selection [esp|esp8266|darwin|mac|windows_nt|windows|win|linux|lin|esp32|wasm|pico|nrf52]
     [--list-devices/--noList-devices]  Select target device or platform SDK to set up from a list; defaults to false
     [--tool]                           Install additional tooling to support common development tasks                                                                 [ejectfix]
     [--branch]                         The remote branch to use as the source for Moddable SDK set up
     [--release]                        The release tag to use as the source for Moddable SDK set up; defaults to `latest`
     [--source-repo]                    URL for remote repository to use as source for Moddable SDK set up; defaults to upstream project
     [--interactive/--noInteractive]    Choose whether to show any prompts or automatically accept them; defaults to true unless CI environment variable is true.
  -h  --help                            Print help information and exit
```