### PR TITLE
docs: update NodeJS version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Moddable SDK and associated dev board tooling is incredibly empowering for e
 
 ## Requirements
 
-[Node.js >= v16](https://nodejs.org/en/)
+[Node.js](https://nodejs.org/en/), at least the [active LTS version](https://nodejs.org/en/about/previous-releases#nodejs-releases).
 
 _If you've never installed Node.js before, check out the [getting started guide for xs-dev](https://hipsterbrown.github.io/xs-dev/guide/00-prepare#nodejs-package-manager-optional)._
 

--- a/docs/src/content/docs/features/doctor.md
+++ b/docs/src/content/docs/features/doctor.md
@@ -15,12 +15,12 @@ This should output something like this:
 
 ```
 xs-dev environment info:
-  CLI Version                0.19.3
+  CLI Version                0.36.5
   OS                         Darwin
   Arch                       arm64
-  NodeJS Version             v16.14.0 (/path/to/node)
-  Python Version             3.10.9 (/path/to/python)
-  Moddable SDK Version       3.5.0 (/path/to/moddable)
+  NodeJS Version             v22.10.0 (/path/to/node)
+  Python Version             3.12.8 (/path/to/python)
+  Moddable SDK Version       5.3.3 (/path/to/moddable)
   Supported target devices   mac, esp32, esp8266, pico
   ESP32 IDF Directory        /path/to/esp32/esp-idf
   ESP8266 Base Directory     /path/to/esp

--- a/docs/src/content/docs/guide/00-prepare.md
+++ b/docs/src/content/docs/guide/00-prepare.md
@@ -34,9 +34,9 @@ These are not the only available editors, so feel free to do your own research a
 
 ## NodeJS & Package Manager (optional)
 
-While [NodeJS](https://nodejs.org/en/) is not required for [Moddable XS](https://github.com/Moddable-OpenSource/moddable) projects, it is a dependency for installing and using the [`xs-dev` CLI](https://xs-dev.js.org/).
+While [NodeJS](https://nodejs.org/en/) is not required for [Moddable XS](https://github.com/Moddable-OpenSource/moddable) projects, it is a dependency for installing and using the [`xs-dev` CLI](https://xs-dev.js.org/). It supports at least the [active Long Term Support (LTS) version](https://nodejs.org/en/about/previous-releases#nodejs-releases).
 
-Node can be [downloaded directly from the website](https://nodejs.org/en/download/), however using one of the following version managers can help with quickly switching to recommended versions of the tooling in the future:
+NodeJS can be [downloaded directly from the website](https://nodejs.org/en/download/), however using one of the following version managers can help with quickly switching to recommended versions of the tooling in the future:
 
 - [mise](https://mise.jdx.dev/getting-started.html#_1-install-mise-cli)
 - [`pnpm env`](https://pnpm.io/cli/env)
@@ -44,7 +44,7 @@ Node can be [downloaded directly from the website](https://nodejs.org/en/downloa
 - [fnm](https://github.com/Schniz/fnm)
 - [asdf](https://asdf-vm.com/guide/getting-started.html#_4-install-a-plugin)
 
-Node comes with [npm](https://docs.npmjs.com/cli/v8/commands/npm) as the included package manager, but there are other options available if needed:
+NodeJS comes with [npm](https://docs.npmjs.com/cli/v8/commands/npm) as the included package manager, but there are other options available if needed:
 
 - [pnpm](https://pnpm.io/installation)
 - [yarn](https://yarnpkg.com/)
@@ -72,6 +72,7 @@ Simulators are fun and everything, but controlling hardware with JavaScript is e
 - [ESP8266](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/devices/esp8266.md)
 - [ESP32](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/devices/esp32.md)
 - [Raspberry Pi Pico](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/devices/pico.md)
+- [Nordic nRF52840](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/devices/nrf52.md)
 
 Each platform has a variety of features and form factors to support whatever you might dream up. This guide will do its best to provide code and diagrams that match the expectations of your chosen device(s) but cannot promise comprehensive coverage of every piece of hardware in existence.
 

--- a/docs/src/content/docs/guide/01-hello-console.md
+++ b/docs/src/content/docs/guide/01-hello-console.md
@@ -96,12 +96,12 @@ Running [`xs-dev doctor` command](/features/doctor) will display relevant info a
 
 ```
 xs-dev environment info:
-  CLI Version                0.19.3
+  CLI Version                0.36.5
   OS                         Darwin
   Arch                       arm64
-  NodeJS Version             v16.14.0 (/path/to/node)
-  Python Version             3.10.9 (/path/to/python)
-  Moddable SDK Version       3.5.0 (/path/to/moddable)
+  NodeJS Version             v22.10.0 (/path/to/node)
+  Python Version             3.12.8 (/path/to/python)
+  Moddable SDK Version       5.3.3 (/path/to/moddable)
   Supported target devices   mac
 
 If this is related to an error when using the CLI, please create an issue at "https://github.com/hipsterbrown/xs-dev/issues/new" with the above info.


### PR DESCRIPTION
Fixes #202

This project is committed to supporting at least the [active LTS version of NodeJS](https://nodejs.org/en/about/previous-releases#nodejs-releases). This is now documented in the README and getting started guide. 